### PR TITLE
Add missing type dependency for cors

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "express": "^4.18.2"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.15",
     "@types/express": "^4.17.17",
     "@types/node": "^20.4.2",
     "ts-node-dev": "^2.0.0",


### PR DESCRIPTION
## Summary
- add the missing @types/cors dependency required by the TypeScript build

## Testing
- not run (dependency installation blocked in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1e5ebd0948330a000777b8760132e