### PR TITLE
Fix backend ESM imports and fallback cors types

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "express": "^4.18.2"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.15",
     "@types/express": "^4.17.17",
     "@types/node": "^20.4.2",
     "ts-node-dev": "^2.0.0",

--- a/backend/src/app/server.ts
+++ b/backend/src/app/server.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
-import { registerAppRoutes } from './setupRoutes';
+import { registerAppRoutes } from './setupRoutes.js';
 
 const app = express();
 app.use(cors());

--- a/backend/src/app/setupRoutes.ts
+++ b/backend/src/app/setupRoutes.ts
@@ -1,11 +1,11 @@
 import { Application } from 'express';
-import { accountsRouter } from '../modules/accounts/accounts.router';
-import { casesRouter } from '../modules/cases/cases.router';
-import { candidatesRouter } from '../modules/candidates/candidates.router';
-import { evaluationsRouter } from '../modules/evaluations/evaluations.router';
-import { questionsRouter } from '../modules/questions/questions.router';
-import { healthRouter } from '../shared/health.router';
-import { authRouter } from '../modules/auth/auth.router';
+import { accountsRouter } from '../modules/accounts/accounts.router.js';
+import { casesRouter } from '../modules/cases/cases.router.js';
+import { candidatesRouter } from '../modules/candidates/candidates.router.js';
+import { evaluationsRouter } from '../modules/evaluations/evaluations.router.js';
+import { questionsRouter } from '../modules/questions/questions.router.js';
+import { healthRouter } from '../shared/health.router.js';
+import { authRouter } from '../modules/auth/auth.router.js';
 
 export const registerAppRoutes = (app: Application) => {
   // TODO: добавить middleware для аутентификации и логирования запросов

--- a/backend/src/modules/accounts/accounts.module.ts
+++ b/backend/src/modules/accounts/accounts.module.ts
@@ -1,3 +1,3 @@
-import { AccountsService } from './accounts.service';
+import { AccountsService } from './accounts.service.js';
 
 export const accountsService = new AccountsService();

--- a/backend/src/modules/accounts/accounts.router.ts
+++ b/backend/src/modules/accounts/accounts.router.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { accountsService } from './accounts.module';
+import { accountsService } from './accounts.module.js';
 
 const router = Router();
 

--- a/backend/src/modules/accounts/accounts.service.ts
+++ b/backend/src/modules/accounts/accounts.service.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import { MailerService } from '../../shared/mailer.service';
+import { MailerService } from '../../shared/mailer.service.js';
 
 export type AccountRole = 'super-admin' | 'admin' | 'user';
 export type AccountStatus = 'pending' | 'active';

--- a/backend/src/modules/auth/auth.router.ts
+++ b/backend/src/modules/auth/auth.router.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { AuthService } from './auth.service';
+import { AuthService } from './auth.service.js';
 
 const router = Router();
 const service = new AuthService();

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto';
-import { accountsService } from '../accounts/accounts.module';
-import { MailerService } from '../../shared/mailer.service';
-import { OtpService } from '../../shared/otp.service';
+import { accountsService } from '../accounts/accounts.module.js';
+import { MailerService } from '../../shared/mailer.service.js';
+import { OtpService } from '../../shared/otp.service.js';
 
 interface AccessCodeRecord {
   email: string;

--- a/backend/src/modules/candidates/candidates.router.ts
+++ b/backend/src/modules/candidates/candidates.router.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { CandidatesService } from './candidates.service';
+import { CandidatesService } from './candidates.service.js';
 
 const router = Router();
 const service = new CandidatesService();

--- a/backend/src/modules/cases/cases.router.ts
+++ b/backend/src/modules/cases/cases.router.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { CasesService } from './cases.service';
+import { CasesService } from './cases.service.js';
 
 const router = Router();
 const service = new CasesService();

--- a/backend/src/modules/evaluations/evaluations.router.ts
+++ b/backend/src/modules/evaluations/evaluations.router.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { EvaluationsService } from './evaluations.service';
+import { EvaluationsService } from './evaluations.service.js';
 
 const router = Router();
 const service = new EvaluationsService();

--- a/backend/src/types/cors.d.ts
+++ b/backend/src/types/cors.d.ts
@@ -1,0 +1,27 @@
+declare module 'cors' {
+  import type { RequestHandler } from 'express';
+
+  // Облегчённое объявление типов для cors, чтобы сборка не падала даже без @types/cors
+  export interface CorsOptions {
+    origin?: boolean | string | RegExp | (string | RegExp)[];
+    methods?: string | string[];
+    allowedHeaders?: string | string[];
+    exposedHeaders?: string | string[];
+    credentials?: boolean;
+    maxAge?: number;
+    preflightContinue?: boolean;
+    optionsSuccessStatus?: number;
+  }
+
+  export interface CorsRequest {
+    method?: string;
+  }
+
+  export interface CorsOptionsDelegate<T extends CorsRequest = CorsRequest> {
+    (req: T, callback: (err: Error | null, options?: CorsOptions) => void): void;
+  }
+
+  export default function cors<T extends CorsRequest = CorsRequest>(
+    options?: CorsOptions | CorsOptionsDelegate<T>
+  ): RequestHandler;
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ES2020",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "dist",
     "rootDir": "src",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- add explicit `.js` extensions to internal ESM imports so the compiled code resolves correctly on Railway
- switch the backend TypeScript compiler to `NodeNext` module resolution to match Node's ESM loader
- add a lightweight `cors` declaration file so builds succeed even if `@types/cors` is temporarily unavailable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1e5ebd0948330a000777b8760132e