### PR TITLE
feat: persist cases data and refine layout

### DIFF
--- a/backend/src/modules/accounts/accounts.router.ts
+++ b/backend/src/modules/accounts/accounts.router.ts
@@ -1,46 +1,65 @@
 import { Router } from 'express';
 import { accountsService } from './accounts.module.js';
+import { AccountRecord } from './accounts.service.js';
 
 const router = Router();
 
+const toDto = (account: AccountRecord) => ({
+  id: account.id,
+  email: account.email,
+  role: account.role,
+  status: account.status,
+  invitedAt: account.createdAt.toISOString(),
+  activatedAt: account.activatedAt ? account.activatedAt.toISOString() : undefined
+});
+
 router.get('/', async (_req, res) => {
   const accounts = await accountsService.listAccounts();
-  res.json(accounts);
+  res.json(accounts.map(toDto));
 });
 
 router.post('/invite', async (req, res) => {
   const { email, role = 'admin' } = req.body as { email?: string; role?: 'admin' | 'user' };
   try {
     const account = await accountsService.inviteAccount(email ?? '', role);
-    res.status(201).json(account);
+    res.status(201).json(toDto(account));
   } catch (error) {
-    if (error instanceof Error && error.message === 'ALREADY_EXISTS') {
-      res.status(409).json({ message: 'Указанный пользователь уже приглашён.' });
-      return;
+    if (error instanceof Error) {
+      if (error.message === 'ALREADY_EXISTS') {
+        res.status(409).json({ message: 'duplicate' });
+        return;
+      }
+      if (error.message === 'INVALID_INVITE') {
+        res.status(400).json({ message: 'invalid-input' });
+        return;
+      }
     }
-    res.status(400).json({ message: 'Не удалось отправить приглашение.' });
+    console.error('[accounts] Ошибка при приглашении пользователя', error);
+    res.status(500).json({ message: 'server-error' });
   }
 });
 
 router.post('/:id/activate', async (req, res) => {
   try {
     const account = await accountsService.activateAccount(req.params.id);
-    res.json(account);
+    res.json(toDto(account));
   } catch (error) {
-    res.status(404).json({ message: 'Аккаунт не найден.' });
+    res.status(404).json({ message: 'not-found' });
   }
 });
 
 router.delete('/:id', async (req, res) => {
   try {
     const account = await accountsService.removeAccount(req.params.id);
-    res.json(account);
+    res.json(toDto(account));
   } catch (error) {
-    if (error instanceof Error && error.message === 'FORBIDDEN') {
-      res.status(403).json({ message: 'Нельзя удалить суперадмина.' });
-      return;
+    if (error instanceof Error) {
+      if (error.message === 'FORBIDDEN') {
+        res.status(403).json({ message: 'invalid-input' });
+        return;
+      }
     }
-    res.status(404).json({ message: 'Аккаунт не найден.' });
+    res.status(404).json({ message: 'not-found' });
   }
 });
 

--- a/backend/src/modules/cases/cases.repository.ts
+++ b/backend/src/modules/cases/cases.repository.ts
@@ -1,35 +1,259 @@
 import { postgresPool } from '../../shared/database/postgres.client.js';
-import type { CaseFolder } from './cases.service.js';
+import {
+  CaseDomainError,
+  CaseFilesUploadPayload,
+  CaseFolder,
+  CaseFileRecord,
+  generateFileId
+} from './cases.types.js';
 
-interface CaseRow extends Record<string, unknown> {
+const pool = postgresPool as unknown as {
+  query: (queryText: string, params?: unknown[]) => Promise<{ rows: any[]; rowCount?: number }>;
+  connect: () => Promise<{
+    query: (queryText: string, params?: unknown[]) => Promise<{ rows: any[]; rowCount?: number }>;
+    release: () => void;
+  }>;
+};
+
+interface FolderRow extends Record<string, unknown> {
   folder_id: string;
   folder_name: string;
+  folder_version: number;
+  folder_created_at: Date;
+  folder_updated_at: Date;
+  file_id: string | null;
   file_name: string | null;
+  file_mime_type: string | null;
+  file_size: number | null;
+  file_data_url: string | null;
+  file_uploaded_at: Date | null;
 }
+
+interface FolderMeta {
+  id: string;
+  name: string;
+  version: number;
+}
+
+const mapRowsToFolder = (rows: FolderRow[]): CaseFolder | null => {
+  if (!rows.length) {
+    return null;
+  }
+
+  const first = rows[0];
+  const files: CaseFileRecord[] = rows
+    .filter((row) => row.file_id)
+    .map((row) => {
+      const uploadedAt = row.file_uploaded_at
+        ? (row.file_uploaded_at as Date).toISOString()
+        : new Date().toISOString();
+      return {
+        id: row.file_id as string,
+        fileName: row.file_name as string,
+        mimeType: (row.file_mime_type as string | null) ?? 'application/octet-stream',
+        size: Number(row.file_size ?? 0),
+        dataUrl: row.file_data_url as string,
+        uploadedAt
+      };
+    });
+
+  return {
+    id: first.folder_id,
+    name: first.folder_name,
+    version: first.folder_version,
+    createdAt: first.folder_created_at.toISOString(),
+    updatedAt: first.folder_updated_at.toISOString(),
+    files
+  };
+};
+
+const folderSelection = `
+  SELECT
+    f.id AS folder_id,
+    f.name AS folder_name,
+    f.version AS folder_version,
+    f.created_at AS folder_created_at,
+    f.updated_at AS folder_updated_at,
+    cf.id AS file_id,
+    cf.file_name AS file_name,
+    cf.mime_type AS file_mime_type,
+    cf.size AS file_size,
+    cf.data_url AS file_data_url,
+    cf.uploaded_at AS file_uploaded_at
+  FROM case_folders f
+  LEFT JOIN case_files cf ON cf.folder_id = f.id
+`;
 
 export class CasesRepository {
   async listFolders(): Promise<CaseFolder[]> {
-    const result = await postgresPool.query<CaseRow>(
-      `SELECT f.id AS folder_id, f.name AS folder_name, cf.file_name
-       FROM case_folders f
-       LEFT JOIN case_files cf ON cf.folder_id = f.id
-       ORDER BY f.created_at DESC, cf.created_at ASC;`
-    );
+    const result = await pool.query(`${folderSelection} ORDER BY f.name ASC, cf.uploaded_at ASC NULLS LAST;`);
+    const rows = result.rows as FolderRow[];
 
-    const folders = new Map<string, CaseFolder>();
-    for (const row of result.rows) {
-      const existing = folders.get(row.folder_id);
-      if (!existing) {
-        folders.set(row.folder_id, {
-          id: row.folder_id,
-          name: row.folder_name,
-          files: row.file_name ? [row.file_name] : []
-        });
-      } else if (row.file_name) {
-        existing.files.push(row.file_name);
-      }
+    const folders = new Map<string, FolderRow[]>();
+    for (const row of rows) {
+      const collection = folders.get(row.folder_id) ?? [];
+      collection.push(row);
+      folders.set(row.folder_id, collection);
     }
 
-    return Array.from(folders.values());
+    return Array.from(folders.values())
+      .map((rows) => mapRowsToFolder(rows))
+      .filter((folder): folder is CaseFolder => Boolean(folder));
+  }
+
+  async findFolderMetaById(id: string): Promise<FolderMeta | null> {
+    const result = await pool.query(`SELECT id, name, version FROM case_folders WHERE id = $1 LIMIT 1;`, [id]);
+    const row = result.rows[0] as FolderMeta | undefined;
+    return row ? { id: row.id, name: row.name, version: row.version } : null;
+  }
+
+  async findFolderByName(name: string): Promise<FolderMeta | null> {
+    const result = await pool.query(
+      `SELECT id, name, version
+         FROM case_folders
+        WHERE LOWER(name) = LOWER($1)
+        LIMIT 1;`,
+      [name]
+    );
+    const row = result.rows[0] as FolderMeta | undefined;
+    return row ? { id: row.id, name: row.name, version: row.version } : null;
+  }
+
+  async insertFolder(id: string, name: string): Promise<CaseFolder> {
+    await pool.query(
+      `INSERT INTO case_folders (id, name)
+       VALUES ($1, $2);`,
+      [id, name]
+    );
+    return this.getFolderById(id);
+  }
+
+  async getFolderById(id: string): Promise<CaseFolder> {
+    const result = await pool.query(`${folderSelection} WHERE f.id = $1 ORDER BY cf.uploaded_at ASC NULLS LAST;`, [id]);
+    const folder = mapRowsToFolder(result.rows as FolderRow[]);
+    if (!folder) {
+      throw new CaseDomainError('not-found');
+    }
+    return folder;
+  }
+
+  async renameFolder(id: string, name: string, expectedVersion: number): Promise<CaseFolder> {
+    const result = await pool.query(
+      `UPDATE case_folders
+          SET name = $2,
+              version = version + 1,
+              updated_at = NOW()
+        WHERE id = $1 AND version = $3
+        RETURNING id;`,
+      [id, name, expectedVersion]
+    );
+
+    if ((result.rowCount ?? 0) === 0) {
+      const exists = await this.findFolderMetaById(id);
+      if (!exists) {
+        throw new CaseDomainError('not-found');
+      }
+      throw new CaseDomainError('version-conflict');
+    }
+
+    return this.getFolderById(id);
+  }
+
+  async deleteFolder(id: string): Promise<boolean> {
+    const result = await pool.query(`DELETE FROM case_folders WHERE id = $1;`, [id]);
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async addFiles(
+    folderId: string,
+    files: CaseFilesUploadPayload[],
+    expectedVersion: number
+  ): Promise<CaseFolder> {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const versionResult = await client.query(`SELECT version FROM case_folders WHERE id = $1 FOR UPDATE;`, [folderId]);
+      const row = versionResult.rows[0] as { version: number } | undefined;
+      if (!row) {
+        throw new CaseDomainError('not-found');
+      }
+      if (row.version !== expectedVersion) {
+        throw new CaseDomainError('version-conflict');
+      }
+
+      for (const file of files) {
+        const fileId = generateFileId();
+        await client.query(
+          `INSERT INTO case_files (id, folder_id, file_name, mime_type, size, data_url, uploaded_at)
+           VALUES ($1, $2, $3, $4, $5, $6, NOW());`,
+          [fileId, folderId, file.fileName, file.mimeType, file.size, file.dataUrl]
+        );
+      }
+
+      await client.query(
+        `UPDATE case_folders
+            SET version = $2,
+                updated_at = NOW()
+          WHERE id = $1;`,
+        [folderId, row.version + 1]
+      );
+
+      await client.query('COMMIT');
+      const folder = await this.getFolderById(folderId);
+      return folder;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      if (error instanceof CaseDomainError) {
+        throw error;
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async removeFile(
+    folderId: string,
+    fileId: string,
+    expectedVersion: number
+  ): Promise<CaseFolder> {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const versionResult = await client.query(`SELECT version FROM case_folders WHERE id = $1 FOR UPDATE;`, [folderId]);
+      const row = versionResult.rows[0] as { version: number } | undefined;
+      if (!row) {
+        throw new CaseDomainError('not-found');
+      }
+      if (row.version !== expectedVersion) {
+        throw new CaseDomainError('version-conflict');
+      }
+
+      const deleteResult = await client.query(`DELETE FROM case_files WHERE id = $1 AND folder_id = $2;`, [fileId, folderId]);
+
+      if ((deleteResult.rowCount ?? 0) === 0) {
+        throw new CaseDomainError('not-found');
+      }
+
+      await client.query(
+        `UPDATE case_folders
+            SET version = $2,
+                updated_at = NOW()
+          WHERE id = $1;`,
+        [folderId, row.version + 1]
+      );
+
+      await client.query('COMMIT');
+      const folder = await this.getFolderById(folderId);
+      return folder;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      if (error instanceof CaseDomainError) {
+        throw error;
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 }

--- a/backend/src/modules/cases/cases.router.ts
+++ b/backend/src/modules/cases/cases.router.ts
@@ -1,11 +1,93 @@
 import { Router } from 'express';
 import { casesService } from './cases.module.js';
+import { CaseDomainError } from './cases.types.js';
 
 const router = Router();
+
+const mapErrorToResponse = (error: unknown, res: any) => {
+  if (error instanceof CaseDomainError) {
+    const payload = { message: error.message || error.code };
+    switch (error.code) {
+      case 'invalid-input':
+        res.status(400).json(payload);
+        return;
+      case 'duplicate':
+        res.status(409).json(payload);
+        return;
+      case 'version-conflict':
+        res.status(409).json(payload);
+        return;
+      case 'not-found':
+      default:
+        res.status(404).json(payload);
+        return;
+    }
+  }
+
+  console.error('[cases] Неожиданная ошибка', error);
+  res.status(500).json({ message: 'Внутренняя ошибка сервера.' });
+};
 
 router.get('/', async (_req, res) => {
   const folders = await casesService.listFolders();
   res.json(folders);
+});
+
+router.post('/', async (req, res) => {
+  try {
+    const folder = await casesService.createFolder(String(req.body?.name ?? ''));
+    res.status(201).json(folder);
+  } catch (error) {
+    mapErrorToResponse(error, res);
+  }
+});
+
+router.patch('/:id', async (req, res) => {
+  try {
+    const folder = await casesService.renameFolder(
+      req.params.id,
+      String(req.body?.name ?? ''),
+      Number(req.body?.expectedVersion ?? NaN)
+    );
+    res.json(folder);
+  } catch (error) {
+    mapErrorToResponse(error, res);
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  try {
+    await casesService.deleteFolder(req.params.id);
+    res.status(204).send();
+  } catch (error) {
+    mapErrorToResponse(error, res);
+  }
+});
+
+router.post('/:id/files', async (req, res) => {
+  try {
+    const folder = await casesService.addFiles(
+      req.params.id,
+      Array.isArray(req.body?.files) ? req.body.files : [],
+      Number(req.body?.expectedVersion ?? NaN)
+    );
+    res.status(201).json(folder);
+  } catch (error) {
+    mapErrorToResponse(error, res);
+  }
+});
+
+router.delete('/:id/files/:fileId', async (req, res) => {
+  try {
+    const folder = await casesService.removeFile(
+      req.params.id,
+      req.params.fileId,
+      Number(req.body?.expectedVersion ?? NaN)
+    );
+    res.json(folder);
+  } catch (error) {
+    mapErrorToResponse(error, res);
+  }
 });
 
 export { router as casesRouter };

--- a/backend/src/modules/cases/cases.service.ts
+++ b/backend/src/modules/cases/cases.service.ts
@@ -1,15 +1,76 @@
 import { CasesRepository } from './cases.repository.js';
-
-export interface CaseFolder {
-  id: string;
-  name: string;
-  files: string[];
-}
+import {
+  CaseDomainError,
+  CaseFilesUploadPayload,
+  CaseFolder,
+  generateFolderId
+} from './cases.types.js';
 
 export class CasesService {
   constructor(private readonly repository: CasesRepository) {}
 
-  async listFolders() {
+  async listFolders(): Promise<CaseFolder[]> {
     return this.repository.listFolders();
+  }
+
+  async createFolder(name: string): Promise<CaseFolder> {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      throw new CaseDomainError('invalid-input');
+    }
+
+    const duplicate = await this.repository.findFolderByName(trimmed);
+    if (duplicate) {
+      throw new CaseDomainError('duplicate');
+    }
+
+    const id = generateFolderId();
+    return this.repository.insertFolder(id, trimmed);
+  }
+
+  async renameFolder(id: string, name: string, expectedVersion: number): Promise<CaseFolder> {
+    if (!Number.isInteger(expectedVersion)) {
+      throw new CaseDomainError('invalid-input');
+    }
+    const trimmed = name.trim();
+    if (!trimmed) {
+      throw new CaseDomainError('invalid-input');
+    }
+
+    const duplicate = await this.repository.findFolderByName(trimmed);
+    if (duplicate && duplicate.id !== id) {
+      throw new CaseDomainError('duplicate');
+    }
+
+    return this.repository.renameFolder(id, trimmed, expectedVersion);
+  }
+
+  async deleteFolder(id: string): Promise<void> {
+    const deleted = await this.repository.deleteFolder(id);
+    if (!deleted) {
+      throw new CaseDomainError('not-found');
+    }
+  }
+
+  async addFiles(
+    folderId: string,
+    files: CaseFilesUploadPayload[],
+    expectedVersion: number
+  ): Promise<CaseFolder> {
+    if (!Number.isInteger(expectedVersion)) {
+      throw new CaseDomainError('invalid-input');
+    }
+    if (!files.length) {
+      throw new CaseDomainError('invalid-input');
+    }
+
+    return this.repository.addFiles(folderId, files, expectedVersion);
+  }
+
+  async removeFile(folderId: string, fileId: string, expectedVersion: number): Promise<CaseFolder> {
+    if (!Number.isInteger(expectedVersion)) {
+      throw new CaseDomainError('invalid-input');
+    }
+    return this.repository.removeFile(folderId, fileId, expectedVersion);
   }
 }

--- a/backend/src/modules/cases/cases.types.ts
+++ b/backend/src/modules/cases/cases.types.ts
@@ -1,0 +1,37 @@
+import { randomUUID } from 'crypto';
+
+export type CaseDomainErrorCode = 'not-found' | 'version-conflict' | 'duplicate' | 'invalid-input';
+
+export class CaseDomainError extends Error {
+  constructor(public readonly code: CaseDomainErrorCode, message?: string) {
+    super(message ?? code);
+  }
+}
+
+export interface CaseFileRecord {
+  id: string;
+  fileName: string;
+  mimeType: string;
+  size: number;
+  uploadedAt: string;
+  dataUrl: string;
+}
+
+export interface CaseFolder {
+  id: string;
+  name: string;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+  files: CaseFileRecord[];
+}
+
+export interface CaseFilesUploadPayload {
+  fileName: string;
+  mimeType: string;
+  size: number;
+  dataUrl: string;
+}
+
+export const generateFolderId = () => randomUUID();
+export const generateFileId = () => randomUUID();

--- a/backend/src/shared/database/migrations.ts
+++ b/backend/src/shared/database/migrations.ts
@@ -43,6 +43,41 @@ const createTables = async () => {
   `);
 
   await postgresPool.query(`
+    ALTER TABLE case_folders
+      ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+  `);
+
+  await postgresPool.query(`
+    ALTER TABLE case_folders
+      ADD COLUMN IF NOT EXISTS version INTEGER NOT NULL DEFAULT 1;
+  `);
+
+  await postgresPool.query(`
+    CREATE UNIQUE INDEX IF NOT EXISTS case_folders_name_unique
+      ON case_folders (LOWER(name));
+  `);
+
+  await postgresPool.query(`
+    ALTER TABLE case_files
+      ADD COLUMN IF NOT EXISTS mime_type TEXT;
+  `);
+
+  await postgresPool.query(`
+    ALTER TABLE case_files
+      ADD COLUMN IF NOT EXISTS size BIGINT;
+  `);
+
+  await postgresPool.query(`
+    ALTER TABLE case_files
+      ADD COLUMN IF NOT EXISTS data_url TEXT;
+  `);
+
+  await postgresPool.query(`
+    ALTER TABLE case_files
+      ADD COLUMN IF NOT EXISTS uploaded_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+  `);
+
+  await postgresPool.query(`
     CREATE TABLE IF NOT EXISTS candidates (
       id UUID PRIMARY KEY,
       first_name TEXT NOT NULL,

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/src/modules/accounts/AccountsScreen.tsx
+++ b/frontend/src/modules/accounts/AccountsScreen.tsx
@@ -28,8 +28,8 @@ export const AccountsScreen = () => {
     );
   }
 
-  const handleInvite = () => {
-    const result = inviteAccount(email, targetRole);
+  const handleInvite = async () => {
+    const result = await inviteAccount(email, targetRole);
     if (!result.ok) {
       const message =
         result.error === 'duplicate'
@@ -42,8 +42,8 @@ export const AccountsScreen = () => {
     setEmail('');
   };
 
-  const handleActivate = (id: string) => {
-    const result = activateAccount(id);
+  const handleActivate = async (id: string) => {
+    const result = await activateAccount(id);
     if (!result.ok) {
       setBanner({ type: 'error', text: 'Не удалось активировать аккаунт.' });
       return;
@@ -51,12 +51,12 @@ export const AccountsScreen = () => {
     setBanner({ type: 'info', text: `Аккаунт ${result.data.email} активирован.` });
   };
 
-  const handleRemove = (id: string) => {
+  const handleRemove = async (id: string) => {
     const confirmed = window.confirm('Удалить аккаунт безвозвратно?');
     if (!confirmed) {
       return;
     }
-    const result = removeAccount(id);
+    const result = await removeAccount(id);
     if (!result.ok) {
       setBanner({ type: 'error', text: 'Не удалось удалить аккаунт.' });
       return;
@@ -88,7 +88,7 @@ export const AccountsScreen = () => {
             <option value="admin">Админ</option>
             <option value="user">Пользователь</option>
           </select>
-          <button className={styles.primaryButton} onClick={handleInvite}>
+          <button className={styles.primaryButton} onClick={() => void handleInvite()}>
             Отправить приглашение
           </button>
         </div>
@@ -124,12 +124,12 @@ export const AccountsScreen = () => {
                 <td>{account.role === 'super-admin' ? 'Суперадмин' : account.role === 'admin' ? 'Админ' : 'Пользователь'}</td>
                 <td className={styles.actionsCell}>
                   {account.status === 'pending' && (
-                    <button className={styles.secondaryButton} onClick={() => handleActivate(account.id)}>
+                    <button className={styles.secondaryButton} onClick={() => void handleActivate(account.id)}>
                       Активировать
                     </button>
                   )}
                   {account.role !== 'super-admin' && (
-                    <button className={styles.dangerButton} onClick={() => handleRemove(account.id)}>
+                    <button className={styles.dangerButton} onClick={() => void handleRemove(account.id)}>
                       Удалить
                     </button>
                   )}

--- a/frontend/src/modules/accounts/api/accountsApi.ts
+++ b/frontend/src/modules/accounts/api/accountsApi.ts
@@ -1,0 +1,40 @@
+import { AccountRecord, AccountRole } from '../../../shared/types/account';
+import { httpClient, HttpError } from '../../../shared/api/httpClient';
+
+const mapError = (error: unknown): HttpError => {
+  if (error instanceof Error) {
+    return error as HttpError;
+  }
+  return new Error('REQUEST_FAILED') as HttpError;
+};
+
+export const accountsApi = {
+  async list(): Promise<AccountRecord[]> {
+    try {
+      return await httpClient.get<AccountRecord[]>('/accounts');
+    } catch (error) {
+      throw mapError(error);
+    }
+  },
+  async invite(email: string, role: AccountRole): Promise<AccountRecord> {
+    try {
+      return await httpClient.post<AccountRecord>('/accounts/invite', { email, role });
+    } catch (error) {
+      throw mapError(error);
+    }
+  },
+  async activate(id: string): Promise<AccountRecord> {
+    try {
+      return await httpClient.post<AccountRecord>(`/accounts/${id}/activate`);
+    } catch (error) {
+      throw mapError(error);
+    }
+  },
+  async remove(id: string): Promise<void> {
+    try {
+      await httpClient.delete<void>(`/accounts/${id}`);
+    } catch (error) {
+      throw mapError(error);
+    }
+  }
+};

--- a/frontend/src/modules/auth/AuthContext.tsx
+++ b/frontend/src/modules/auth/AuthContext.tsx
@@ -1,5 +1,6 @@
-import { createContext, ReactNode, useContext, useState } from 'react';
+import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
 import { AccountRole } from '../../shared/types/account';
+import { accountsApi } from '../accounts/api/accountsApi';
 
 interface AuthContextValue {
   role: AccountRole;
@@ -16,6 +17,25 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [role, setRole] = useState<AccountRole>('super-admin');
   const [email, setEmail] = useState('super.admin@company.com');
   const [rememberMe, setRememberMe] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadSuperAdmin = async () => {
+      try {
+        const accounts = await accountsApi.list();
+        const superAdmin = accounts.find((account) => account.role === 'super-admin');
+        if (!cancelled && superAdmin) {
+          setEmail(superAdmin.email);
+        }
+      } catch (error) {
+        console.error('Не удалось получить email суперадмина', error);
+      }
+    };
+    void loadSuperAdmin();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   return (
     <AuthContext.Provider value={{ role, setRole, email, setEmail, rememberMe, setRememberMe }}>

--- a/frontend/src/modules/cases/CasesScreen.tsx
+++ b/frontend/src/modules/cases/CasesScreen.tsx
@@ -15,8 +15,8 @@ export const CasesScreen = () => {
     [folders]
   );
 
-  const handleCreateFolder = () => {
-    const result = createFolder(newFolderName);
+  const handleCreateFolder = async () => {
+    const result = await createFolder(newFolderName);
     if (!result.ok) {
       setErrorMessage(result.error === 'duplicate' ? 'Папка с таким именем уже существует.' : 'Введите корректное название.');
       setInfoMessage(null);
@@ -28,7 +28,7 @@ export const CasesScreen = () => {
   };
 
   const handleRename = async (folderId: string, folderVersion: number, name: string) => {
-    const result = renameFolder(folderId, name, folderVersion);
+    const result = await renameFolder(folderId, name, folderVersion);
     if (!result.ok) {
       if (result.error === 'version-conflict') {
         throw new Error('Папка была изменена другим пользователем. Обновите страницу.');
@@ -42,12 +42,12 @@ export const CasesScreen = () => {
     setErrorMessage(null);
   };
 
-  const handleDelete = (folderId: string) => {
+  const handleDelete = async (folderId: string) => {
     const confirmed = window.confirm('Удалить папку и все вложенные файлы безвозвратно?');
     if (!confirmed) {
       return;
     }
-    const result = deleteFolder(folderId);
+    const result = await deleteFolder(folderId);
     if (!result.ok) {
       setErrorMessage('Не удалось удалить папку.');
       return;
@@ -58,7 +58,7 @@ export const CasesScreen = () => {
 
   const handleUpload = async (folderId: string, folderVersion: number, files: File[]) => {
     const records = await convertFilesToRecords(files);
-    const result = registerFiles(folderId, records, folderVersion);
+    const result = await registerFiles(folderId, records, folderVersion);
     if (!result.ok) {
       if (result.error === 'version-conflict') {
         throw new Error('Файлы не сохранены: папка была изменена другим пользователем.');
@@ -70,7 +70,7 @@ export const CasesScreen = () => {
   };
 
   const handleRemoveFile = async (folderId: string, folderVersion: number, fileId: string) => {
-    const result = removeFile(folderId, fileId, folderVersion);
+    const result = await removeFile(folderId, fileId, folderVersion);
     if (!result.ok) {
       if (result.error === 'version-conflict') {
         throw new Error('Файл не удалён: в папке уже есть свежие изменения.');
@@ -94,7 +94,7 @@ export const CasesScreen = () => {
             onChange={(event) => setNewFolderName(event.target.value)}
             placeholder="Название новой папки"
           />
-          <button className={styles.primaryButton} onClick={handleCreateFolder}>
+          <button className={styles.primaryButton} onClick={() => void handleCreateFolder()}>
             Создать папку
           </button>
         </div>
@@ -119,7 +119,7 @@ export const CasesScreen = () => {
                 key={folder.id}
                 folder={folder}
                 onRename={(name) => handleRename(folder.id, folder.version, name)}
-                onDelete={() => handleDelete(folder.id)}
+                onDelete={() => void handleDelete(folder.id)}
                 onUpload={(files) => handleUpload(folder.id, folder.version, files)}
                 onRemoveFile={(fileId) => handleRemoveFile(folder.id, folder.version, fileId)}
               />

--- a/frontend/src/modules/cases/api/casesApi.ts
+++ b/frontend/src/modules/cases/api/casesApi.ts
@@ -1,0 +1,71 @@
+import { CaseFolder } from '../../../shared/types/caseLibrary';
+import { httpClient, HttpError } from '../../../shared/api/httpClient';
+
+export interface CaseFileUploadDto {
+  fileName: string;
+  mimeType: string;
+  size: number;
+  dataUrl: string;
+}
+
+const mapError = (error: unknown): HttpError => {
+  if (error instanceof Error) {
+    return error as HttpError;
+  }
+  return new Error('REQUEST_FAILED') as HttpError;
+};
+
+export const casesApi = {
+  async list(): Promise<CaseFolder[]> {
+    try {
+      return await httpClient.get<CaseFolder[]>('/cases');
+    } catch (error) {
+      throw mapError(error);
+    }
+  },
+  async create(name: string): Promise<CaseFolder> {
+    try {
+      return await httpClient.post<CaseFolder>('/cases', { name });
+    } catch (error) {
+      throw mapError(error);
+    }
+  },
+  async rename(id: string, name: string, expectedVersion: number): Promise<CaseFolder> {
+    try {
+      return await httpClient.patch<CaseFolder>(`/cases/${id}`, { name, expectedVersion });
+    } catch (error) {
+      throw mapError(error);
+    }
+  },
+  async remove(id: string): Promise<void> {
+    try {
+      await httpClient.delete<void>(`/cases/${id}`);
+    } catch (error) {
+      throw mapError(error);
+    }
+  },
+  async uploadFiles(
+    id: string,
+    files: CaseFileUploadDto[],
+    expectedVersion: number
+  ): Promise<CaseFolder> {
+    try {
+      return await httpClient.post<CaseFolder>(`/cases/${id}/files`, { files, expectedVersion });
+    } catch (error) {
+      throw mapError(error);
+    }
+  },
+  async removeFile(
+    id: string,
+    fileId: string,
+    expectedVersion: number
+  ): Promise<CaseFolder> {
+    try {
+      return await httpClient.delete<CaseFolder>(`/cases/${id}/files/${fileId}`, {
+        expectedVersion
+      });
+    } catch (error) {
+      throw mapError(error);
+    }
+  }
+};

--- a/frontend/src/modules/cases/components/CaseFolderCard.tsx
+++ b/frontend/src/modules/cases/components/CaseFolderCard.tsx
@@ -64,7 +64,7 @@ export const CaseFolderCard = ({ folder, onRename, onDelete, onUpload, onRemoveF
 
   const renderFile = (file: CaseFileRecord) => (
     <li key={file.id} className={styles.fileRow}>
-      <div>
+      <div className={styles.fileInfo}>
         <p className={styles.fileName}>{file.fileName}</p>
         <p className={styles.fileMeta}>
           {Math.round(file.size / 1024)} Кб · {new Date(file.uploadedAt).toLocaleString('ru-RU')}
@@ -109,14 +109,6 @@ export const CaseFolderCard = ({ folder, onRename, onDelete, onUpload, onRemoveF
             </>
           )}
         </div>
-        <div className={styles.folderActions}>
-          <button className={styles.secondaryButton} onClick={() => setIsEditingName((prev) => !prev)}>
-            {isEditingName ? 'Отмена' : 'Переименовать'}
-          </button>
-          <button className={styles.dangerButton} onClick={onDelete}>
-            Удалить
-          </button>
-        </div>
       </header>
 
       <div
@@ -144,6 +136,15 @@ export const CaseFolderCard = ({ folder, onRename, onDelete, onUpload, onRemoveF
       ) : (
         <ul className={styles.filesList}>{folder.files.map(renderFile)}</ul>
       )}
+
+      <div className={styles.folderActionsFooter}>
+        <button className={styles.secondaryButton} onClick={() => setIsEditingName((prev) => !prev)}>
+          {isEditingName ? 'Отмена' : 'Переименовать'}
+        </button>
+        <button className={styles.dangerButton} onClick={onDelete}>
+          Удалить
+        </button>
+      </div>
 
       <footer className={styles.folderFooter}>
         <span>Обновлено: {new Date(folder.updatedAt).toLocaleString('ru-RU')}</span>

--- a/frontend/src/modules/cases/services/fileAdapter.ts
+++ b/frontend/src/modules/cases/services/fileAdapter.ts
@@ -1,5 +1,4 @@
-import { CaseFileRecord } from '../../../shared/types/caseLibrary';
-import { generateId } from '../../../shared/ui/generateId';
+import { CaseFileUploadDto } from '../api/casesApi';
 
 const readFileAsDataUrl = (file: File) =>
   new Promise<string>((resolve, reject) => {
@@ -9,15 +8,12 @@ const readFileAsDataUrl = (file: File) =>
     reader.readAsDataURL(file);
   });
 
-export const convertFilesToRecords = async (files: File[]): Promise<CaseFileRecord[]> => {
-  const timestamp = new Date().toISOString();
+export const convertFilesToRecords = async (files: File[]): Promise<CaseFileUploadDto[]> => {
   const records = await Promise.all(
     files.map(async (file) => ({
-      id: generateId(),
       fileName: file.name,
       mimeType: file.type,
       size: file.size,
-      uploadedAt: timestamp,
       dataUrl: await readFileAsDataUrl(file)
     }))
   );

--- a/frontend/src/shared/api/httpClient.ts
+++ b/frontend/src/shared/api/httpClient.ts
@@ -1,0 +1,59 @@
+const rawBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:4000';
+const normalizedBaseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+
+const buildUrl = (path: string) =>
+  `${normalizedBaseUrl}${path.startsWith('/') ? path : `/${path}`}`;
+
+const parseJson = async (response: Response) => {
+  if (response.status === 204) {
+    return null;
+  }
+  const text = await response.text();
+  try {
+    return text ? JSON.parse(text) : null;
+  } catch (error) {
+    console.error('Не удалось разобрать ответ сервера:', error);
+    return null;
+  }
+};
+
+const request = async <T>(path: string, init: RequestInit = {}): Promise<T> => {
+  const response = await fetch(buildUrl(path), {
+    credentials: 'include',
+    ...init
+  });
+
+  if (!response.ok) {
+    const payload = await parseJson(response);
+    const message = typeof payload?.message === 'string' ? payload.message : 'REQUEST_FAILED';
+    const error = new Error(message);
+    (error as Error & { status?: number }).status = response.status;
+    throw error;
+  }
+
+  return (await parseJson(response)) as T;
+};
+
+export const httpClient = {
+  get: <T>(path: string) => request<T>(path),
+  post: <T>(path: string, body?: unknown) =>
+    request<T>(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: body ? JSON.stringify(body) : undefined
+    }),
+  patch: <T>(path: string, body?: unknown) =>
+    request<T>(path, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: body ? JSON.stringify(body) : undefined
+    }),
+  delete: <T>(path: string, body?: unknown) =>
+    request<T>(path, {
+      method: 'DELETE',
+      headers: body ? { 'Content-Type': 'application/json' } : undefined,
+      body: body ? JSON.stringify(body) : undefined
+    })
+};
+
+export type HttpError = Error & { status?: number };

--- a/frontend/src/styles/CasesScreen.module.css
+++ b/frontend/src/styles/CasesScreen.module.css
@@ -24,12 +24,14 @@
 .primaryButton,
 .secondaryButton,
 .dangerButton {
-  padding: 12px 20px;
-  border-radius: 12px;
+  padding: 8px 16px;
+  border-radius: 10px;
   border: none;
   cursor: pointer;
   transition: transform 0.2s ease;
   font-weight: 600;
+  font-size: 14px;
+  line-height: 1.4;
 }
 
 .primaryButton {
@@ -100,7 +102,7 @@
 
 .foldersGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
   gap: 24px;
 }
 
@@ -129,6 +131,7 @@
   display: flex;
   justify-content: space-between;
   gap: 16px;
+  align-items: flex-start;
 }
 
 .folderHeader h3 {
@@ -141,14 +144,10 @@
   font-size: 14px;
 }
 
-.folderActions {
-  display: flex;
-  gap: 12px;
-}
-
 .renameRow {
   display: flex;
-  gap: 12px;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 .renameRow input {
@@ -191,11 +190,17 @@
 
 .fileRow {
   display: flex;
-  justify-content: space-between;
-  gap: 16px;
+  flex-direction: column;
+  gap: 12px;
   padding: 16px;
   border-radius: 16px;
   background: rgba(255, 255, 255, 0.8);
+}
+
+.fileInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .fileName {
@@ -211,7 +216,15 @@
 
 .fileActions {
   display: flex;
-  gap: 12px;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.folderActionsFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 .folderFooter {


### PR DESCRIPTION
## Summary
- добавить полноценные REST-эндпоинты и схему хранения папок кейсов с файлами в БД, включая версии и метаданные
- интегрировать фронтенд с API для кейсов и аккаунтов, синхронизируя состояние и загрузку данных
- обновить интерфейс управления кейсами: компактные кнопки, перенос действий и новые сетки, а также подтягивание email суперадмина с сервера

## Testing
- npm run build (backend)
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68e21de5e2f8833083770d4180be7850