### PR TITLE
Исправлено определение базового URL API во фронтенде

### DIFF
--- a/frontend/src/shared/api/httpClient.ts
+++ b/frontend/src/shared/api/httpClient.ts
@@ -28,18 +28,42 @@ const buildHeaders = (input?: HeadersInit, body?: unknown) => {
   return headers;
 };
 
-const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:4000';
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '');
+
+const resolveDefaultBase = () => {
+  // В девелопменте явно подключаемся к локальному API, чтобы не ломать DX.
+  if (import.meta.env.DEV) {
+    return 'http://localhost:4000';
+  }
+
+  // В продакшене стараемся бить в тот же origin, где открыт фронтенд.
+  if (typeof window !== 'undefined' && window.location.origin) {
+    return window.location.origin;
+  }
+
+  // Фолбэк нужен для SSR/тестов, где window недоступен.
+  return 'http://localhost:4000';
+};
+
+const API_BASE = trimTrailingSlash((import.meta.env.VITE_API_URL as string | undefined)?.trim() ?? resolveDefaultBase());
 
 export const apiRequest = async <T>(
   path: string,
   options: RequestOptions = {}
 ): Promise<T> => {
   const { body, headers, ...rest } = options;
-  const response = await fetch(`${API_BASE}${path}`, {
-    ...rest,
-    headers: buildHeaders(headers, body),
-    body: resolveBody(body)
-  });
+  let response: Response;
+
+  try {
+    response = await fetch(`${API_BASE}${path}`, {
+      ...rest,
+      headers: buildHeaders(headers, body),
+      body: resolveBody(body)
+    });
+  } catch (error) {
+    // Нормализуем сетевые ошибки до единого формата.
+    throw new ApiError(0, 'network-error', (error as Error)?.message ?? 'Не удалось выполнить запрос.');
+  }
 
   const text = await response.text();
   const payload = text ? JSON.parse(text) : null;


### PR DESCRIPTION
## Summary
- добавлена автоматическая подстановка origin веб-клиента для обращения к API в production
- нормализованы сетевые ошибки до единого формата ApiError

## Testing
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68e23194c9cc8330851228a1d95137e5