### PR TITLE
Adjust API base URL detection for production proxy

### DIFF
--- a/frontend/src/shared/api/httpClient.ts
+++ b/frontend/src/shared/api/httpClient.ts
@@ -28,25 +28,89 @@ const buildHeaders = (input?: HeadersInit, body?: unknown) => {
   return headers;
 };
 
-const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:4000';
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '');
+
+const ensureAbsoluteUrl = (value: string, fallbackOrigin: string) => {
+  // Поддерживаем относительные пути из переменных окружения, чтобы конфигурация деплоя
+  // оставалась гибкой и независимой от конкретного домена.
+  if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value)) {
+    return value;
+  }
+
+  const normalizedPath = value.startsWith('/') ? value : `/${value}`;
+  return new URL(normalizedPath, fallbackOrigin).toString();
+};
+
+const resolveApiBase = () => {
+  const fallbackOrigin = typeof window === 'undefined' ? 'http://localhost:4000' : window.location.origin;
+  const explicitBase = import.meta.env.VITE_API_URL?.trim();
+
+  if (explicitBase) {
+    return trimTrailingSlash(ensureAbsoluteUrl(explicitBase, fallbackOrigin));
+  }
+
+  if (typeof window === 'undefined') {
+    return 'http://localhost:4000';
+  }
+
+  const hostname = window.location.hostname.toLowerCase();
+
+  // В продакшене обращаемся к API через префикс /api на текущем домене,
+  // чтобы статический фронтенд и сервер находились за одним источником.
+  if (hostname !== 'localhost' && hostname !== '127.0.0.1') {
+    return trimTrailingSlash(new URL('/api', window.location.origin).toString());
+  }
+
+  // Для локальной разработки оставляем привычный порт API.
+  return 'http://localhost:4000';
+};
+
+const API_BASE = resolveApiBase();
+
+const buildUrl = (path: string) => {
+  const normalizedBase = API_BASE.endsWith('/') ? API_BASE : `${API_BASE}/`;
+  return new URL(path.replace(/^\//, ''), normalizedBase).toString();
+};
 
 export const apiRequest = async <T>(
   path: string,
   options: RequestOptions = {}
 ): Promise<T> => {
   const { body, headers, ...rest } = options;
-  const response = await fetch(`${API_BASE}${path}`, {
+  const response = await fetch(buildUrl(path), {
     ...rest,
     headers: buildHeaders(headers, body),
     body: resolveBody(body)
   });
 
   const text = await response.text();
-  const payload = text ? JSON.parse(text) : null;
+  let payload: unknown = null;
+
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch (error) {
+      const snippet = text.slice(0, 120).trim();
+
+      if (!response.ok) {
+        throw new ApiError(response.status, undefined, 'Не удалось выполнить запрос.');
+      }
+
+      throw new Error(
+        `Сервер вернул неожиданный ответ: ${snippet || 'пустое тело'}. Проверьте конфигурацию API.`
+      );
+    }
+  }
+
+  const structuredPayload =
+    payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : null;
 
   if (!response.ok) {
-    const message = payload?.message ?? 'Не удалось выполнить запрос.';
-    const code = payload?.code as string | undefined;
+    const messageValue = structuredPayload?.message;
+    const codeValue = structuredPayload?.code;
+
+    const message = typeof messageValue === 'string' ? messageValue : 'Не удалось выполнить запрос.';
+    const code = typeof codeValue === 'string' ? codeValue : undefined;
     throw new ApiError(response.status, code, message);
   }
 


### PR DESCRIPTION
## Summary
- allow VITE_API_URL to be relative and resolve against the current origin
- default the implicit production API base to the current origin with an /api prefix
- harden response parsing to surface non-JSON replies from the server

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e23194c9cc8330851228a1d95137e5