### PR TITLE
Fix API base URL resolution and session handling for production deployments

### DIFF
--- a/frontend/src/shared/api/httpClient.ts
+++ b/frontend/src/shared/api/httpClient.ts
@@ -10,6 +10,9 @@ export class ApiError extends Error {
 
 type RequestOptions = Omit<RequestInit, 'body'> & { body?: unknown };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
 const resolveBody = (body: unknown) => {
   if (body === undefined || body === null) {
     return undefined;
@@ -28,25 +31,79 @@ const buildHeaders = (input?: HeadersInit, body?: unknown) => {
   return headers;
 };
 
-const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:4000';
+const resolveApiBase = () => {
+  const explicitBase = import.meta.env.VITE_API_URL?.trim();
+  if (explicitBase) {
+    return explicitBase.replace(/\/$/, '');
+  }
+
+  if (typeof window === 'undefined') {
+    return 'http://localhost:4000';
+  }
+
+  const hostname = window.location.hostname.toLowerCase();
+
+  // В продакшене используем тот же домен, чтобы не зависеть от локальных адресов.
+  if (hostname !== 'localhost' && hostname !== '127.0.0.1') {
+    return window.location.origin;
+  }
+
+  // Для локальной разработки оставляем привычный порт API.
+  return 'http://localhost:4000';
+};
+
+const API_BASE = resolveApiBase();
+
+const buildUrl = (path: string) => {
+  const normalizedBase = API_BASE.endsWith('/') ? API_BASE : `${API_BASE}/`;
+  return new URL(path.replace(/^\//, ''), normalizedBase).toString();
+};
 
 export const apiRequest = async <T>(
   path: string,
   options: RequestOptions = {}
 ): Promise<T> => {
-  const { body, headers, ...rest } = options;
-  const response = await fetch(`${API_BASE}${path}`, {
+  const { body, headers, credentials, ...rest } = options;
+
+  const response = await fetch(buildUrl(path), {
     ...rest,
+    // По умолчанию отправляем куки, чтобы сервер видел текущую сессию.
+    credentials: credentials ?? 'include',
     headers: buildHeaders(headers, body),
     body: resolveBody(body)
   });
 
   const text = await response.text();
-  const payload = text ? JSON.parse(text) : null;
+  let payload: unknown = null;
+
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch (error) {
+      console.error('Сервер вернул неожиданный формат ответа:', {
+        status: response.status,
+        preview: text.slice(0, 120)
+      });
+
+      throw new ApiError(
+        response.status || 0,
+        undefined,
+        'Сервер вернул данные в неизвестном формате.'
+      );
+    }
+  }
 
   if (!response.ok) {
-    const message = payload?.message ?? 'Не удалось выполнить запрос.';
-    const code = payload?.code as string | undefined;
+    const message =
+      isRecord(payload) && typeof payload.message === 'string'
+        ? payload.message
+        : 'Не удалось выполнить запрос.';
+
+    const code =
+      isRecord(payload) && typeof payload.code === 'string'
+        ? payload.code
+        : undefined;
+
     throw new ApiError(response.status, code, message);
   }
 


### PR DESCRIPTION
## Summary
- detect the appropriate API base URL at runtime instead of assuming localhost
- keep local development pointing to http://localhost:4000 while production uses the current origin
- include session cookies in API calls and surface unexpected response formats so HTML redirects no longer break JSON parsing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e23194c9cc8330851228a1d95137e5