### PR TITLE
Implement email OTP login flow with session persistence

### DIFF
--- a/backend/src/app/server.ts
+++ b/backend/src/app/server.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import express from 'express';
-import cors from 'cors';
+import cors, { type CorsOptions } from 'cors';
 import { registerAppRoutes } from './setupRoutes.js';
 import { runMigrations } from '../shared/database/migrations.js';
 
@@ -9,7 +9,29 @@ const bootstrap = async () => {
   await runMigrations();
 
   const app = express();
-  app.use(cors());
+
+  const allowedOrigins = (process.env.CORS_ALLOWED_ORIGINS || '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  const corsOptions: CorsOptions = {
+    credentials: true,
+    origin: (origin, callback) => {
+      // Разрешаем запросы без Origin (например, от curl) и любые домены, если список пустой
+      if (!origin || allowedOrigins.length === 0) {
+        callback(null, true);
+        return;
+      }
+      if (allowedOrigins.includes(origin)) {
+        callback(null, true);
+        return;
+      }
+      callback(new Error('Origin not allowed by CORS policy'));
+    }
+  };
+
+  app.use(cors(corsOptions));
   app.use(express.json({ limit: '10mb' }));
 
   registerAppRoutes(app);

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -1,6 +1,8 @@
 import { AuthService } from './auth.service.js';
 import { accountsService } from '../accounts/accounts.module.js';
 import { AccessCodesRepository } from './accessCodes.repository.js';
+import { SessionsRepository } from './sessions.repository.js';
 
 const codesRepository = new AccessCodesRepository();
-export const authService = new AuthService(accountsService, codesRepository);
+const sessionsRepository = new SessionsRepository();
+export const authService = new AuthService(accountsService, codesRepository, sessionsRepository);

--- a/backend/src/modules/auth/auth.router.ts
+++ b/backend/src/modules/auth/auth.router.ts
@@ -1,5 +1,30 @@
-import { Router } from 'express';
+import { Router, type Response } from 'express';
 import { authService } from './auth.module.js';
+import { readCookie } from '../../shared/http/cookies.js';
+import { EXTENDED_SESSION_TTL_MS, SESSION_TTL_MS } from './auth.service.js';
+
+const SESSION_COOKIE_NAME = 'session_token';
+const COOKIE_SECURE = process.env.AUTH_COOKIE_SECURE === 'true';
+const COOKIE_DOMAIN = process.env.AUTH_COOKIE_DOMAIN?.trim();
+
+const buildCookieOptions = (rememberMe: boolean) => ({
+  httpOnly: true,
+  sameSite: 'lax' as const,
+  secure: COOKIE_SECURE,
+  maxAge: rememberMe ? EXTENDED_SESSION_TTL_MS : SESSION_TTL_MS,
+  path: '/',
+  ...(COOKIE_DOMAIN ? { domain: COOKIE_DOMAIN } : {})
+});
+
+const clearSessionCookie = (res: Response) => {
+  res.clearCookie(SESSION_COOKIE_NAME, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: COOKIE_SECURE,
+    path: '/',
+    ...(COOKIE_DOMAIN ? { domain: COOKIE_DOMAIN } : {})
+  });
+};
 
 const router = Router();
 
@@ -13,13 +38,18 @@ router.post('/request-code', async (req, res) => {
 });
 
 router.post('/verify-code', async (req, res) => {
-  const { email, code } = req.body as { email?: string; code?: string };
+  const { email, code, rememberMe = false } = req.body as {
+    email?: string;
+    code?: string;
+    rememberMe?: boolean;
+  };
   if (!email || !code) {
     res.status(400).json({ message: 'Provide email and access code.' });
     return;
   }
   try {
-    const session = await authService.verifyAccessCode(email, code);
+    const session = await authService.verifyAccessCode(email, code, Boolean(rememberMe));
+    res.cookie(SESSION_COOKIE_NAME, session.token, buildCookieOptions(session.rememberMe));
     res.json(session);
   } catch (error) {
     if (error instanceof Error && error.message === 'CODE_EXPIRED') {
@@ -28,6 +58,36 @@ router.post('/verify-code', async (req, res) => {
     }
     res.status(401).json({ message: 'Invalid code.' });
   }
+});
+
+router.get('/session', async (req, res) => {
+  const token = readCookie(req, SESSION_COOKIE_NAME);
+  if (!token) {
+    res.status(401).json({ message: 'Not authenticated.' });
+    return;
+  }
+  const session = await authService.getSession(token);
+  if (!session) {
+    clearSessionCookie(res);
+    res.status(401).json({ message: 'Session expired.' });
+    return;
+  }
+  res.json({
+    token: session.token,
+    email: session.email,
+    role: session.role,
+    expiresAt: session.expiresAt.toISOString(),
+    rememberMe: session.rememberMe
+  });
+});
+
+router.post('/logout', async (req, res) => {
+  const token = readCookie(req, SESSION_COOKIE_NAME);
+  if (token) {
+    await authService.logout(token);
+  }
+  clearSessionCookie(res);
+  res.status(204).end();
 });
 
 export { router as authRouter };

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -3,22 +3,28 @@ import type { AccountsService } from '../accounts/accounts.service.js';
 import { MailerService } from '../../shared/mailer.service.js';
 import { OtpService } from '../../shared/otp.service.js';
 import { AccessCodesRepository } from './accessCodes.repository.js';
+import { SessionsRepository } from './sessions.repository.js';
+
+export const CODE_TTL_MS = 10 * 60 * 1000;
+export const SESSION_TTL_MS = 12 * 60 * 60 * 1000;
+export const EXTENDED_SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
 export class AuthService {
   constructor(
     private readonly accountsService: AccountsService,
     private readonly codesRepository = new AccessCodesRepository(),
+    private readonly sessionsRepository = new SessionsRepository(),
     private readonly mailer = new MailerService(),
     private readonly otp = new OtpService()
   ) {}
 
   async requestAccessCode(email: string) {
     const account = await this.accountsService.findByEmail(email.trim().toLowerCase());
-    if (!account) {
+    if (!account || (account.role !== 'admin' && account.role !== 'super-admin')) {
       throw new Error('ACCOUNT_NOT_FOUND');
     }
     const code = this.otp.generateCode();
-    const expiresAt = new Date(Date.now() + 5 * 60 * 1000);
+    const expiresAt = new Date(Date.now() + CODE_TTL_MS);
     await this.codesRepository.saveCode({
       email: account.email,
       code,
@@ -28,7 +34,7 @@ export class AuthService {
     return { email: account.email };
   }
 
-  async verifyAccessCode(email: string, code: string) {
+  async verifyAccessCode(email: string, code: string, rememberMe: boolean) {
     const normalized = email.trim().toLowerCase();
     const record = await this.codesRepository.findCode(normalized, code);
     if (!record) {
@@ -40,7 +46,7 @@ export class AuthService {
     }
 
     const account = await this.accountsService.findByEmail(normalized);
-    if (!account) {
+    if (!account || (account.role !== 'admin' && account.role !== 'super-admin')) {
       await this.codesRepository.deleteCode(normalized);
       throw new Error('ACCOUNT_NOT_FOUND');
     }
@@ -51,10 +57,32 @@ export class AuthService {
 
     await this.codesRepository.deleteCode(normalized);
 
+    const sessionExpiresAt = new Date(
+      Date.now() + (rememberMe ? EXTENDED_SESSION_TTL_MS : SESSION_TTL_MS)
+    );
+    const token = randomUUID();
+
+    await this.sessionsRepository.createSession({
+      token,
+      accountId: account.id,
+      expiresAt: sessionExpiresAt,
+      rememberMe
+    });
+
     return {
-      token: randomUUID(),
+      token,
       role: account.role,
-      email: account.email
+      email: account.email,
+      expiresAt: sessionExpiresAt.toISOString(),
+      rememberMe
     };
+  }
+
+  async getSession(token: string) {
+    return this.sessionsRepository.findActiveSession(token);
+  }
+
+  async logout(token: string) {
+    await this.sessionsRepository.deleteByToken(token);
   }
 }

--- a/backend/src/modules/auth/sessions.repository.ts
+++ b/backend/src/modules/auth/sessions.repository.ts
@@ -1,0 +1,76 @@
+import { postgresPool } from '../../shared/database/postgres.client.js';
+
+interface SessionRow {
+  token: string;
+  account_id: string;
+  expires_at: string;
+  remember_me: boolean;
+  created_at: string;
+  account_email: string;
+  account_role: string;
+  account_status: string;
+}
+
+export interface SessionRecord {
+  token: string;
+  accountId: string;
+  email: string;
+  role: string;
+  expiresAt: Date;
+  rememberMe: boolean;
+}
+
+export class SessionsRepository {
+  // Удаляем просроченные сессии перед выполнением операций
+  async purgeExpiredSessions() {
+    await postgresPool.query('DELETE FROM sessions WHERE expires_at < NOW();');
+  }
+
+  async createSession(record: { token: string; accountId: string; expiresAt: Date; rememberMe: boolean }) {
+    await this.purgeExpiredSessions();
+    await postgresPool.query(
+      `INSERT INTO sessions (token, account_id, expires_at, remember_me, created_at)
+       VALUES ($1, $2, $3, $4, NOW())`,
+      [record.token, record.accountId, record.expiresAt, record.rememberMe]
+    );
+  }
+
+  async deleteByToken(token: string) {
+    await postgresPool.query('DELETE FROM sessions WHERE token = $1;', [token]);
+  }
+
+  async findActiveSession(token: string): Promise<SessionRecord | null> {
+    await this.purgeExpiredSessions();
+    const result = await postgresPool.query<SessionRow>(
+      `SELECT s.token,
+              s.account_id,
+              s.expires_at,
+              s.remember_me,
+              s.created_at,
+              a.email AS account_email,
+              a.role AS account_role,
+              a.status AS account_status
+         FROM sessions s
+         JOIN accounts a ON a.id = s.account_id
+        WHERE s.token = $1
+        LIMIT 1;`,
+      [token]
+    );
+    const row = result.rows[0];
+    if (!row) {
+      return null;
+    }
+    if (row.account_status !== 'active') {
+      await this.deleteByToken(token);
+      return null;
+    }
+    return {
+      token: row.token,
+      accountId: row.account_id,
+      email: row.account_email,
+      role: row.account_role,
+      expiresAt: new Date(row.expires_at),
+      rememberMe: row.remember_me
+    };
+  }
+}

--- a/backend/src/shared/database/migrations.ts
+++ b/backend/src/shared/database/migrations.ts
@@ -29,6 +29,16 @@ const createTables = async () => {
   `);
 
   await postgresPool.query(`
+    CREATE TABLE IF NOT EXISTS sessions (
+      token UUID PRIMARY KEY,
+      account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+      expires_at TIMESTAMPTZ NOT NULL,
+      remember_me BOOLEAN NOT NULL DEFAULT FALSE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+  `);
+
+  await postgresPool.query(`
     CREATE TABLE IF NOT EXISTS case_folders (
       id UUID PRIMARY KEY,
       name TEXT NOT NULL,

--- a/backend/src/shared/http/cookies.ts
+++ b/backend/src/shared/http/cookies.ts
@@ -1,0 +1,22 @@
+import type { Request } from 'express';
+
+const parseCookies = (cookieHeader: string | undefined): Record<string, string> => {
+  if (!cookieHeader) {
+    return {};
+  }
+  return cookieHeader.split(';').reduce<Record<string, string>>((acc, part) => {
+    const [rawName, ...rawValue] = part.split('=');
+    const name = rawName?.trim();
+    if (!name) {
+      return acc;
+    }
+    const value = rawValue.join('=').trim();
+    acc[name] = decodeURIComponent(value);
+    return acc;
+  }, {});
+};
+
+export const readCookie = (req: Request, name: string): string | undefined => {
+  const cookies = parseCookies(req.headers.cookie);
+  return cookies[name];
+};

--- a/backend/src/shared/mailer.service.ts
+++ b/backend/src/shared/mailer.service.ts
@@ -213,11 +213,27 @@ export class MailerService {
   async sendInvitation(email: string, token: string) {
     const subject = 'Invitation to the case management system';
     const inviteUrl = process.env.INVITE_URL?.trim();
+
+    const link = inviteUrl
+      ? (() => {
+          try {
+            const url = new URL(inviteUrl);
+            url.searchParams.set('token', token);
+            return url.toString();
+          } catch (error) {
+            console.warn('Failed to format invitation URL:', error);
+            return inviteUrl;
+          }
+        })()
+      : null;
+
     const bodyLines = [
       'You have been invited to the case management system.',
-      inviteUrl ? `Activation link: ${inviteUrl}` : null,
-      `Invitation token: ${token}`
+      link ? `Open the dashboard: ${link}` : null,
+      `Invitation token: ${token}`,
+      'Use the dashboard to request a one-time access code.'
     ].filter((line): line is string => Boolean(line));
+
     await this.deliver(email, subject, bodyLines.join('\n\n'));
   }
 

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,7 +9,8 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,15 +7,19 @@ import { EvaluationScreen } from './modules/evaluation/EvaluationScreen';
 import { AccountsScreen } from './modules/accounts/AccountsScreen';
 import { PlaceholderScreen } from './shared/ui/PlaceholderScreen';
 import { AuthProvider, useAuth } from './modules/auth/AuthContext';
+import { LoginScreen } from './modules/auth/LoginScreen';
 import { AppStateProvider } from './app/state/AppStateContext';
 
 const AppContent = () => {
-  const { role } = useAuth();
+  const { session, loading } = useAuth();
   const [activePage, setActivePage] = useState<NavigationKey>('cases');
 
   const accessibleItems = useMemo(
-    () => navigationItems.filter((item) => item.roleAccess.includes(role)),
-    [role]
+    () =>
+      session
+        ? navigationItems.filter((item) => item.roleAccess.includes(session.role))
+        : [],
+    [session]
   );
 
   useEffect(() => {
@@ -23,6 +27,18 @@ const AppContent = () => {
       setActivePage(accessibleItems[0]?.key ?? 'evaluation');
     }
   }, [accessibleItems, activePage]);
+
+  if (loading) {
+    return (
+      <div style={{ minHeight: '100vh', display: 'grid', placeItems: 'center', background: '#0f172a' }}>
+        <p style={{ color: '#f8fafc', fontSize: '16px' }}>Loading the dashboard…</p>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return <LoginScreen />;
+  }
 
   const renderContent = () => {
     switch (activePage) {
@@ -65,9 +81,9 @@ const AppContent = () => {
 };
 
 export const App = () => (
-  <AppStateProvider>
-    <AuthProvider>
+  <AuthProvider>
+    <AppStateProvider>
       <AppContent />
-    </AuthProvider>
-  </AppStateProvider>
+    </AppStateProvider>
+  </AuthProvider>
 );

--- a/frontend/src/app/AppLayout.tsx
+++ b/frontend/src/app/AppLayout.tsx
@@ -3,13 +3,12 @@ import { NavigationItem, NavigationKey } from './navigation';
 import { Sidebar } from '../components/layout/Sidebar';
 import styles from '../styles/AppLayout.module.css';
 import { useAuth } from '../modules/auth/AuthContext';
-import { AccountRole } from '../shared/types/account';
 
-const roleLabels: Record<AccountRole, string> = {
+const roleLabels = {
   'super-admin': 'Super admin',
   admin: 'Admin',
   user: 'User'
-};
+} as const;
 
 interface AppLayoutProps {
   navigationItems: NavigationItem[];
@@ -19,7 +18,11 @@ interface AppLayoutProps {
 }
 
 export const AppLayout = ({ navigationItems, activeItem, onNavigate, children }: AppLayoutProps) => {
-  const { role, setRole, email } = useAuth();
+  const { session } = useAuth();
+
+  if (!session) {
+    return null;
+  }
 
   return (
     <div className={styles.container}>
@@ -31,17 +34,12 @@ export const AppLayout = ({ navigationItems, activeItem, onNavigate, children }:
       <main className={styles.content}>
         <div className={styles.topbar}>
           <div>
-            <p className={styles.topbarGreeting}>Welcome, {email}</p>
-            <p className={styles.topbarHint}>Choose a role to test access segregation.</p>
+            <p className={styles.topbarGreeting}>Welcome, {session.email}</p>
+            <p className={styles.topbarHint}>Role: {roleLabels[session.role]}</p>
           </div>
-          <label className={styles.roleSelector}>
-            <span>Current role</span>
-            <select value={role} onChange={(event) => setRole(event.target.value as typeof role)}>
-              <option value="super-admin">{roleLabels['super-admin']}</option>
-              <option value="admin">{roleLabels.admin}</option>
-              <option value="user">{roleLabels.user}</option>
-            </select>
-          </label>
+          <div className={styles.topbarHintBlock}>
+            <p className={styles.topbarHintSecondary}>Use the sidebar to move between sections.</p>
+          </div>
         </div>
         <div className={styles.pageContainer}>{children}</div>
       </main>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -9,7 +9,7 @@ interface SidebarProps {
 }
 
 export const Sidebar = ({ navigationItems, activeItem, onNavigate }: SidebarProps) => {
-  const { setRole } = useAuth();
+  const { session, logout } = useAuth();
 
   return (
     <aside className={styles.sidebar}>
@@ -20,6 +20,12 @@ export const Sidebar = ({ navigationItems, activeItem, onNavigate }: SidebarProp
           <span className={styles.version}>2.0</span>
         </div>
       </div>
+      {session && (
+        <div className={styles.userSummary}>
+          <p className={styles.userEmail}>{session.email}</p>
+          <p className={styles.userRole}>{session.role === 'super-admin' ? 'Super admin' : session.role === 'admin' ? 'Admin' : 'User'}</p>
+        </div>
+      )}
       <nav className={styles.menu}>
         {navigationItems.map((item) => (
           <button
@@ -35,8 +41,7 @@ export const Sidebar = ({ navigationItems, activeItem, onNavigate }: SidebarProp
         <button
           className={styles.logoutButton}
           onClick={() => {
-            // Placeholder for future backend integration
-            setRole('user');
+            void logout();
           }}
         >
           Sign out

--- a/frontend/src/modules/accounts/AccountsScreen.tsx
+++ b/frontend/src/modules/accounts/AccountsScreen.tsx
@@ -6,7 +6,8 @@ import { useAuth } from '../auth/AuthContext';
 type Banner = { type: 'info' | 'error'; text: string } | null;
 
 export const AccountsScreen = () => {
-  const { role } = useAuth();
+  const { session } = useAuth();
+  const role = session?.role ?? 'user';
   const { list, inviteAccount, activateAccount, removeAccount } = useAccountsState();
   const [email, setEmail] = useState('');
   const [targetRole, setTargetRole] = useState<'admin' | 'user'>('admin');

--- a/frontend/src/modules/auth/AuthContext.tsx
+++ b/frontend/src/modules/auth/AuthContext.tsx
@@ -1,45 +1,109 @@
-import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
-import { AccountRole } from '../../shared/types/account';
-import { useAccountsState } from '../../app/state/AppStateContext';
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
+import { authApi } from './services/authApi';
+import { AuthSession } from '../../shared/types/auth';
+
+interface RequestCodeSuccess {
+  ok: true;
+  email: string;
+}
+
+export type RequestCodeError = 'invalid-email' | 'not-found' | 'unknown';
+
+export type RequestCodeResult = RequestCodeSuccess | { ok: false; error: RequestCodeError };
+
+interface VerifyCodeSuccess {
+  ok: true;
+  session: AuthSession;
+}
+
+export type VerifyCodeError = 'invalid' | 'expired' | 'unknown';
+
+export type VerifyCodeResult = VerifyCodeSuccess | { ok: false; error: VerifyCodeError };
 
 interface AuthContextValue {
-  role: AccountRole;
-  setRole: (role: AccountRole) => void;
-  email: string;
-  setEmail: (email: string) => void;
-  rememberMe: boolean;
-  setRememberMe: (value: boolean) => void;
+  session: AuthSession | null;
+  loading: boolean;
+  requestCode: (email: string) => Promise<RequestCodeResult>;
+  verifyCode: (email: string, code: string, remember: boolean) => Promise<VerifyCodeResult>;
+  logout: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
-  const { list } = useAccountsState();
-  const [role, setRole] = useState<AccountRole>('super-admin');
-  const [email, setEmailState] = useState('—');
-  const [rememberMe, setRememberMe] = useState(true);
-  const [emailLocked, setEmailLocked] = useState(false);
+  const [session, setSession] = useState<AuthSession | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (emailLocked) {
-      return;
-    }
-    const superAdmin = list.find((account) => account.role === 'super-admin');
-    if (superAdmin) {
-      setEmailState(superAdmin.email);
-    }
-  }, [list, emailLocked]);
+    let cancelled = false;
 
-  const setEmail = (value: string) => {
-    setEmailState(value);
-    setEmailLocked(true);
-  };
+    const bootstrap = async () => {
+      const result = await authApi.loadSession();
+      if (cancelled) {
+        return;
+      }
+      if (result.ok) {
+        setSession(result.session);
+      }
+      setLoading(false);
+    };
 
-  return (
-    <AuthContext.Provider value={{ role, setRole, email, setEmail, rememberMe, setRememberMe }}>
-      {children}
-    </AuthContext.Provider>
+    void bootstrap();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const requestCode = useCallback(async (email: string): Promise<RequestCodeResult> => {
+    const normalized = email.trim().toLowerCase();
+    if (!normalized) {
+      return { ok: false, error: 'invalid-email' };
+    }
+    const result = await authApi.requestCode(normalized);
+    if (result.ok) {
+      return { ok: true, email: normalized };
+    }
+    return { ok: false, error: result.error };
+  }, []);
+
+  const verifyCode = useCallback(
+    async (email: string, code: string, remember: boolean): Promise<VerifyCodeResult> => {
+      const normalizedEmail = email.trim().toLowerCase();
+      const trimmedCode = code.trim();
+      if (!normalizedEmail || !trimmedCode) {
+        return { ok: false, error: 'invalid' };
+      }
+      const result = await authApi.verifyCode(normalizedEmail, trimmedCode, remember);
+      if (result.ok) {
+        setSession(result.session);
+        return { ok: true, session: result.session };
+      }
+      return { ok: false, error: result.error };
+    },
+    []
   );
+
+  const logout = useCallback(async () => {
+    // Даже если запрос завершится ошибкой, локально сбрасываем сессию
+    await authApi.logout();
+    setSession(null);
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ session, loading, requestCode, verifyCode, logout }),
+    [loading, logout, requestCode, session, verifyCode]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };
 
 export const useAuth = () => {

--- a/frontend/src/modules/auth/LoginScreen.tsx
+++ b/frontend/src/modules/auth/LoginScreen.tsx
@@ -1,0 +1,160 @@
+import { FormEvent, useState } from 'react';
+import styles from '../../styles/LoginScreen.module.css';
+import { useAuth, RequestCodeError, VerifyCodeError } from './AuthContext';
+
+interface StatusMessage {
+  type: 'info' | 'error';
+  text: string;
+}
+
+const mapRequestError = (error: RequestCodeError): string => {
+  switch (error) {
+    case 'invalid-email':
+      return 'Enter a valid email address.';
+    case 'not-found':
+      return 'We could not find an admin account with this email.';
+    default:
+      return 'Something went wrong. Try again later.';
+  }
+};
+
+const mapVerifyError = (error: VerifyCodeError): string => {
+  switch (error) {
+    case 'invalid':
+      return 'The access code is incorrect.';
+    case 'expired':
+      return 'The code has expired. Request a new one.';
+    default:
+      return 'Failed to confirm the access code. Try again later.';
+  }
+};
+
+export const LoginScreen = () => {
+  const { requestCode, verifyCode } = useAuth();
+  const [stage, setStage] = useState<'email' | 'code'>('email');
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [rememberMe, setRememberMe] = useState(false);
+  const [status, setStatus] = useState<StatusMessage | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleRequest = async (event: FormEvent) => {
+    event.preventDefault();
+    if (submitting) {
+      return;
+    }
+    setSubmitting(true);
+    const result = await requestCode(email);
+    if (result.ok) {
+      // Сохраняем нормализованный email, чтобы уменьшить ошибки при вводе кода
+      setEmail(result.email);
+      setStage('code');
+      setStatus({ type: 'info', text: `We sent a code to ${result.email}.` });
+      setCode('');
+    } else {
+      setStatus({ type: 'error', text: mapRequestError(result.error) });
+    }
+    setSubmitting(false);
+  };
+
+  const handleVerify = async (event: FormEvent) => {
+    event.preventDefault();
+    if (submitting) {
+      return;
+    }
+    setSubmitting(true);
+    const result = await verifyCode(email, code, rememberMe);
+    if (result.ok) {
+      setStatus(null);
+    } else {
+      setStatus({ type: 'error', text: mapVerifyError(result.error) });
+    }
+    setSubmitting(false);
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.panel}>
+        <header className={styles.header}>
+          <div className={styles.logo}>R2</div>
+          <div>
+            <h1>Recruitment 2.0</h1>
+            <p className={styles.subtitle}>Secure sign-in for admin accounts.</p>
+          </div>
+        </header>
+
+        {stage === 'email' && (
+          <form className={styles.form} onSubmit={handleRequest}>
+            <label className={styles.label}>
+              Email
+              <input
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                placeholder="admin@company.com"
+                autoComplete="email"
+                required
+              />
+            </label>
+            <button type="submit" className={styles.primaryButton} disabled={submitting}>
+              {submitting ? 'Sending…' : 'Send access code'}
+            </button>
+            <p className={styles.hint}>You will receive a six-digit code in the inbox.</p>
+          </form>
+        )}
+
+        {stage === 'code' && (
+          <form className={styles.form} onSubmit={handleVerify}>
+            <div className={styles.confirmationBlock}>
+              <p className={styles.infoLine}>Code sent to {email}</p>
+              <button
+                type="button"
+                className={styles.linkButton}
+                onClick={() => {
+                  setStage('email');
+                  setStatus(null);
+                }}
+              >
+                Use another email
+              </button>
+            </div>
+            <label className={styles.label}>
+              Access code
+              <input
+                type="text"
+                inputMode="numeric"
+                maxLength={6}
+                value={code}
+                onChange={(event) => setCode(event.target.value)}
+                placeholder="000000"
+                autoComplete="one-time-code"
+                required
+              />
+            </label>
+            <label className={styles.checkbox}>
+              <input
+                type="checkbox"
+                checked={rememberMe}
+                onChange={(event) => setRememberMe(event.target.checked)}
+              />
+              Keep me signed in on this device
+            </label>
+            <button type="submit" className={styles.primaryButton} disabled={submitting}>
+              {submitting ? 'Checking…' : 'Confirm code'}
+            </button>
+            <p className={styles.hint}>The code expires in ten minutes. Request a new one if needed.</p>
+          </form>
+        )}
+
+        {status && (
+          <div
+            className={status.type === 'info' ? styles.infoBanner : styles.errorBanner}
+            role="status"
+          >
+            {status.text}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/modules/auth/services/authApi.ts
+++ b/frontend/src/modules/auth/services/authApi.ts
@@ -1,0 +1,73 @@
+import { apiRequest, ApiError } from '../../../shared/api/httpClient';
+import { AuthSession } from '../../../shared/types/auth';
+
+type RequestCodeApiResult = { ok: true } | { ok: false; error: 'not-found' | 'unknown' };
+type VerifyCodeApiResult =
+  | { ok: true; session: AuthSession }
+  | { ok: false; error: 'invalid' | 'expired' | 'unknown' };
+type LoadSessionApiResult =
+  | { ok: true; session: AuthSession }
+  | { ok: false; error: 'unauthorized' | 'unknown' };
+type LogoutApiResult = { ok: true } | { ok: false; error: 'unknown' };
+
+export const authApi = {
+  async requestCode(email: string): Promise<RequestCodeApiResult> {
+    try {
+      await apiRequest<{ email: string }>('/auth/request-code', {
+        method: 'POST',
+        body: { email }
+      });
+      return { ok: true };
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 404) {
+        return { ok: false, error: 'not-found' };
+      }
+      console.error('Failed to request access code:', error);
+      return { ok: false, error: 'unknown' };
+    }
+  },
+
+  async verifyCode(email: string, code: string, rememberMe: boolean): Promise<VerifyCodeApiResult> {
+    try {
+      const session = await apiRequest<AuthSession>('/auth/verify-code', {
+        method: 'POST',
+        body: { email, code, rememberMe }
+      });
+      return { ok: true, session };
+    } catch (error) {
+      if (error instanceof ApiError) {
+        if (error.status === 410) {
+          return { ok: false, error: 'expired' };
+        }
+        if (error.status === 401) {
+          return { ok: false, error: 'invalid' };
+        }
+      }
+      console.error('Failed to verify access code:', error);
+      return { ok: false, error: 'unknown' };
+    }
+  },
+
+  async loadSession(): Promise<LoadSessionApiResult> {
+    try {
+      const session = await apiRequest<AuthSession>('/auth/session');
+      return { ok: true, session };
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 401) {
+        return { ok: false, error: 'unauthorized' };
+      }
+      console.error('Failed to load auth session:', error);
+      return { ok: false, error: 'unknown' };
+    }
+  },
+
+  async logout(): Promise<LogoutApiResult> {
+    try {
+      await apiRequest<void>('/auth/logout', { method: 'POST' });
+      return { ok: true };
+    } catch (error) {
+      console.error('Failed to logout:', error);
+      return { ok: false, error: 'unknown' };
+    }
+  }
+};

--- a/frontend/src/shared/api/httpClient.ts
+++ b/frontend/src/shared/api/httpClient.ts
@@ -37,6 +37,7 @@ export const apiRequest = async <T>(
   const { body, headers, ...rest } = options;
   const response = await fetch(buildApiUrl(path), {
     ...rest,
+    credentials: 'include',
     headers: buildHeaders(headers, body),
     body: resolveBody(body)
   });

--- a/frontend/src/shared/types/auth.ts
+++ b/frontend/src/shared/types/auth.ts
@@ -1,0 +1,9 @@
+import { AccountRole } from './account';
+
+export interface AuthSession {
+  token: string;
+  email: string;
+  role: AccountRole;
+  expiresAt: string;
+  rememberMe: boolean;
+}

--- a/frontend/src/shared/types/results.ts
+++ b/frontend/src/shared/types/results.ts
@@ -3,6 +3,7 @@ export type DomainErrorCode =
   | 'version-conflict'
   | 'duplicate'
   | 'invalid-input'
+  | 'unauthorized'
   | 'unknown';
 
 export interface DomainFailure {

--- a/frontend/src/styles/AppLayout.module.css
+++ b/frontend/src/styles/AppLayout.module.css
@@ -38,21 +38,18 @@
   color: #475569;
 }
 
-.roleSelector {
+.topbarHintBlock {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-  font-size: 14px;
-  color: #334155;
+  align-items: flex-end;
+  justify-content: flex-end;
+  text-align: right;
+  flex: 1;
 }
 
-.roleSelector select {
-  border: 1px solid rgba(148, 163, 184, 0.6);
-  border-radius: 12px;
-  padding: 8px 12px;
-  font-size: 14px;
-  background: #ffffff;
-  color: #0f172a;
+.topbarHintSecondary {
+  margin: 0;
+  font-size: 13px;
+  color: #64748b;
 }
 
 .pageContainer {

--- a/frontend/src/styles/LoginScreen.module.css
+++ b/frontend/src/styles/LoginScreen.module.css
@@ -1,0 +1,157 @@
+.wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #0f172a, #1e293b 45%, #020617);
+  padding: 24px;
+}
+
+.panel {
+  width: min(420px, 100%);
+  background: rgba(15, 23, 42, 0.9);
+  border-radius: 24px;
+  padding: 40px 36px;
+  box-shadow: 0 24px 60px rgba(2, 6, 23, 0.55);
+  color: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.header {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.logo {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #38bdf8 0%, #818cf8 100%);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 22px;
+}
+
+.subtitle {
+  margin: 4px 0 0;
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 14px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 14px;
+}
+
+.label input {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 12px 14px;
+  font-size: 16px;
+  background: rgba(15, 23, 42, 0.6);
+  color: #f8fafc;
+}
+
+.label input::placeholder {
+  color: rgba(226, 232, 240, 0.5);
+}
+
+.label input:focus {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.9);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.35);
+}
+
+.primaryButton {
+  border: none;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: #0f172a;
+  transition: transform 0.15s ease;
+}
+
+.primaryButton:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
+.primaryButton:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+.hint {
+  margin: 0;
+  font-size: 12px;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.infoBanner,
+.errorBanner {
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-size: 14px;
+}
+
+.infoBanner {
+  background: rgba(14, 165, 233, 0.15);
+  border: 1px solid rgba(56, 189, 248, 0.4);
+  color: #67e8f9;
+}
+
+.errorBanner {
+  background: rgba(239, 68, 68, 0.15);
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  color: #fecaca;
+}
+
+.confirmationBlock {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.infoLine {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.linkButton {
+  border: none;
+  background: none;
+  color: #38bdf8;
+  cursor: pointer;
+  font-size: 13px;
+  text-decoration: underline;
+  padding: 4px;
+}
+
+.checkbox {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 14px;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.checkbox input {
+  width: 18px;
+  height: 18px;
+}

--- a/frontend/src/styles/Sidebar.module.css
+++ b/frontend/src/styles/Sidebar.module.css
@@ -40,6 +40,30 @@
   color: #cbd5f5;
 }
 
+.userSummary {
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.userEmail {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #e0f2fe;
+  word-break: break-word;
+}
+
+.userRole {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(203, 213, 225, 0.8);
+  text-transform: capitalize;
+}
+
 .menu {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add one-time code login with session storage, invitation email updates, and cookie-based auth endpoints
- configure backend CORS and frontend HTTP client/auth API for credentialed requests
- build OTP login UI, session-aware context, and logout handling across the dashboard

## Testing
- npm run build (frontend)
- npm run build (backend) *(fails: npm registry 403 when installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e248ed37ec8330a34cdca3c3958b03