### PR TITLE
Implement email one-time code login workflow

### DIFF
--- a/backend/src/modules/auth/auth.router.ts
+++ b/backend/src/modules/auth/auth.router.ts
@@ -8,7 +8,17 @@ router.post('/request-code', async (req, res) => {
     const result = await authService.requestAccessCode(String(req.body.email ?? ''));
     res.status(201).json(result);
   } catch (error) {
-    res.status(404).json({ message: 'Account not found or access denied.' });
+    if (error instanceof Error) {
+      if (error.message === 'ACCOUNT_NOT_FOUND') {
+        res.status(404).json({ message: 'Account not found.' });
+        return;
+      }
+      if (error.message === 'ACCESS_DENIED') {
+        res.status(403).json({ message: 'Access denied for this account.' });
+        return;
+      }
+    }
+    res.status(500).json({ message: 'Failed to request an access code.' });
   }
 });
 
@@ -22,9 +32,15 @@ router.post('/verify-code', async (req, res) => {
     const session = await authService.verifyAccessCode(email, code);
     res.json(session);
   } catch (error) {
-    if (error instanceof Error && error.message === 'CODE_EXPIRED') {
-      res.status(410).json({ message: 'Code expired. Request a new one.' });
-      return;
+    if (error instanceof Error) {
+      if (error.message === 'CODE_EXPIRED') {
+        res.status(410).json({ message: 'Code expired. Request a new one.' });
+        return;
+      }
+      if (error.message === 'ACCOUNT_NOT_FOUND') {
+        res.status(404).json({ message: 'Account not found.' });
+        return;
+      }
     }
     res.status(401).json({ message: 'Invalid code.' });
   }

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -17,8 +17,11 @@ export class AuthService {
     if (!account) {
       throw new Error('ACCOUNT_NOT_FOUND');
     }
+    if (account.role !== 'admin' && account.role !== 'super-admin') {
+      throw new Error('ACCESS_DENIED');
+    }
     const code = this.otp.generateCode();
-    const expiresAt = new Date(Date.now() + 5 * 60 * 1000);
+    const expiresAt = new Date(Date.now() + 10 * 60 * 1000);
     await this.codesRepository.saveCode({
       email: account.email,
       code,

--- a/backend/src/shared/mailer.service.ts
+++ b/backend/src/shared/mailer.service.ts
@@ -213,10 +213,19 @@ export class MailerService {
   async sendInvitation(email: string, token: string) {
     const subject = 'Invitation to the case management system';
     const inviteUrl = process.env.INVITE_URL?.trim();
+    const separator = inviteUrl && inviteUrl.includes('?') ? '&' : '?';
+    const activationLink = inviteUrl
+      ? `${inviteUrl}${separator}email=${encodeURIComponent(email)}&invitation=${encodeURIComponent(token)}`
+      : null;
     const bodyLines = [
       'You have been invited to the case management system.',
-      inviteUrl ? `Activation link: ${inviteUrl}` : null,
-      `Invitation token: ${token}`
+      activationLink
+        ? `Open this link to activate your access: ${activationLink}`
+        : inviteUrl
+          ? `Open this link to activate your access: ${inviteUrl}`
+          : null,
+      `If the link is unavailable, use this invitation token: ${token}`,
+      'Once activated, return to the login page and request a one-time access code.'
     ].filter((line): line is string => Boolean(line));
     await this.deliver(email, subject, bodyLines.join('\n\n'));
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,14 +8,25 @@ import { AccountsScreen } from './modules/accounts/AccountsScreen';
 import { PlaceholderScreen } from './shared/ui/PlaceholderScreen';
 import { AuthProvider, useAuth } from './modules/auth/AuthContext';
 import { AppStateProvider } from './app/state/AppStateContext';
+import { LoginScreen } from './modules/auth/LoginScreen';
 
 const AppContent = () => {
-  const { role } = useAuth();
+  const { session } = useAuth();
   const [activePage, setActivePage] = useState<NavigationKey>('cases');
 
+  useEffect(() => {
+    if (!session) {
+      setActivePage('cases');
+    }
+  }, [session]);
+
+  if (!session) {
+    return <LoginScreen />;
+  }
+
   const accessibleItems = useMemo(
-    () => navigationItems.filter((item) => item.roleAccess.includes(role)),
-    [role]
+    () => navigationItems.filter((item) => item.roleAccess.includes(session.role)),
+    [session.role]
   );
 
   useEffect(() => {
@@ -65,9 +76,9 @@ const AppContent = () => {
 };
 
 export const App = () => (
-  <AppStateProvider>
-    <AuthProvider>
+  <AuthProvider>
+    <AppStateProvider>
       <AppContent />
-    </AuthProvider>
-  </AppStateProvider>
+    </AppStateProvider>
+  </AuthProvider>
 );

--- a/frontend/src/app/AppLayout.tsx
+++ b/frontend/src/app/AppLayout.tsx
@@ -19,7 +19,11 @@ interface AppLayoutProps {
 }
 
 export const AppLayout = ({ navigationItems, activeItem, onNavigate, children }: AppLayoutProps) => {
-  const { role, setRole, email } = useAuth();
+  const { session } = useAuth();
+
+  if (!session) {
+    return null;
+  }
 
   return (
     <div className={styles.container}>
@@ -31,17 +35,10 @@ export const AppLayout = ({ navigationItems, activeItem, onNavigate, children }:
       <main className={styles.content}>
         <div className={styles.topbar}>
           <div>
-            <p className={styles.topbarGreeting}>Welcome, {email}</p>
-            <p className={styles.topbarHint}>Choose a role to test access segregation.</p>
+            <p className={styles.topbarGreeting}>Welcome back</p>
+            <p className={styles.topbarHint}>Signed in as {session.email}</p>
           </div>
-          <label className={styles.roleSelector}>
-            <span>Current role</span>
-            <select value={role} onChange={(event) => setRole(event.target.value as typeof role)}>
-              <option value="super-admin">{roleLabels['super-admin']}</option>
-              <option value="admin">{roleLabels.admin}</option>
-              <option value="user">{roleLabels.user}</option>
-            </select>
-          </label>
+          <span className={styles.roleBadge}>{roleLabels[session.role]}</span>
         </div>
         <div className={styles.pageContainer}>{children}</div>
       </main>

--- a/frontend/src/app/state/AppStateContext.tsx
+++ b/frontend/src/app/state/AppStateContext.tsx
@@ -7,6 +7,7 @@ import { DomainResult } from '../../shared/types/results';
 import { casesApi } from '../../modules/cases/services/casesApi';
 import { accountsApi } from '../../modules/accounts/services/accountsApi';
 import { ApiError } from '../../shared/api/httpClient';
+import { useAuth } from '../../modules/auth/AuthContext';
 
 interface AppStateContextValue {
   cases: {
@@ -64,6 +65,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
   const [candidates, setCandidates] = useState<CandidateProfile[]>([]);
   const [evaluations, setEvaluations] = useState<EvaluationConfig[]>([]);
   const [accounts, setAccounts] = useState<AccountRecord[]>([]);
+  const { session } = useAuth();
 
   const syncFolders = useCallback(async (): Promise<CaseFolder[] | null> => {
     try {
@@ -77,10 +79,18 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   useEffect(() => {
+    if (!session) {
+      setFolders([]);
+      return;
+    }
     void syncFolders();
-  }, [syncFolders]);
+  }, [session, syncFolders]);
 
   useEffect(() => {
+    if (!session) {
+      setAccounts([]);
+      return;
+    }
     const loadAccounts = async () => {
       try {
         const remote = await accountsApi.list();
@@ -90,7 +100,14 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
       }
     };
     void loadAccounts();
-  }, []);
+  }, [session]);
+
+  useEffect(() => {
+    if (!session) {
+      setCandidates([]);
+      setEvaluations([]);
+    }
+  }, [session]);
 
   const value = useMemo<AppStateContextValue>(() => ({
     cases: {

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -9,7 +9,7 @@ interface SidebarProps {
 }
 
 export const Sidebar = ({ navigationItems, activeItem, onNavigate }: SidebarProps) => {
-  const { setRole } = useAuth();
+  const { session, logout } = useAuth();
 
   return (
     <aside className={styles.sidebar}>
@@ -32,12 +32,10 @@ export const Sidebar = ({ navigationItems, activeItem, onNavigate }: SidebarProp
         ))}
       </nav>
       <div className={styles.logoutBlock}>
+        {session && <p className={styles.sessionInfo}>{session.email}</p>}
         <button
           className={styles.logoutButton}
-          onClick={() => {
-            // Placeholder for future backend integration
-            setRole('user');
-          }}
+          onClick={() => logout()}
         >
           Sign out
         </button>

--- a/frontend/src/modules/accounts/AccountsScreen.tsx
+++ b/frontend/src/modules/accounts/AccountsScreen.tsx
@@ -6,7 +6,8 @@ import { useAuth } from '../auth/AuthContext';
 type Banner = { type: 'info' | 'error'; text: string } | null;
 
 export const AccountsScreen = () => {
-  const { role } = useAuth();
+  const { session } = useAuth();
+  const role = session?.role ?? 'user';
   const { list, inviteAccount, activateAccount, removeAccount } = useAccountsState();
   const [email, setEmail] = useState('');
   const [targetRole, setTargetRole] = useState<'admin' | 'user'>('admin');
@@ -40,7 +41,7 @@ export const AccountsScreen = () => {
       setBanner({ type: 'error', text: message });
       return;
     }
-    setBanner({ type: 'info', text: `Invitation sent to ${result.data.email}.` });
+    setBanner({ type: 'info', text: `Invitation email sent to ${result.data.email}.` });
     setEmail('');
   };
 

--- a/frontend/src/modules/auth/AuthContext.tsx
+++ b/frontend/src/modules/auth/AuthContext.tsx
@@ -1,45 +1,253 @@
-import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
 import { AccountRole } from '../../shared/types/account';
-import { useAccountsState } from '../../app/state/AppStateContext';
+import { ApiError } from '../../shared/api/httpClient';
+import { authApi } from './services/authApi';
+
+export interface AuthSession {
+  token: string;
+  email: string;
+  role: AccountRole;
+  expiresAt: number;
+}
+
+export type RequestCodeError = 'not-found' | 'forbidden' | 'unknown';
+export type VerifyCodeError = 'invalid' | 'expired' | 'unknown';
+
+interface RequestCodeSuccess {
+  ok: true;
+  email: string;
+}
+
+interface RequestCodeFailure {
+  ok: false;
+  error: RequestCodeError;
+}
+
+export type RequestCodeResult = RequestCodeSuccess | RequestCodeFailure;
+
+interface VerifyCodeSuccess {
+  ok: true;
+  session: AuthSession;
+}
+
+interface VerifyCodeFailure {
+  ok: false;
+  error: VerifyCodeError;
+}
+
+export type VerifyCodeResult = VerifyCodeSuccess | VerifyCodeFailure;
 
 interface AuthContextValue {
-  role: AccountRole;
-  setRole: (role: AccountRole) => void;
-  email: string;
-  setEmail: (email: string) => void;
-  rememberMe: boolean;
-  setRememberMe: (value: boolean) => void;
+  session: AuthSession | null;
+  isAuthenticated: boolean;
+  requestAccessCode: (email: string) => Promise<RequestCodeResult>;
+  verifyAccessCode: (email: string, code: string, remember: boolean) => Promise<VerifyCodeResult>;
+  logout: () => void;
+  lastEmail: string | null;
 }
+
+const SESSION_STORAGE_KEY = 'recruitment:session';
+const LAST_EMAIL_KEY = 'recruitment:last-email';
+const LONG_SESSION_MS = 30 * 24 * 60 * 60 * 1000;
+const SHORT_SESSION_MS = 12 * 60 * 60 * 1000;
+
+const isBrowserEnvironment = () => typeof window !== 'undefined';
+
+const readStoredSession = (): AuthSession | null => {
+  if (!isBrowserEnvironment()) {
+    return null;
+  }
+
+  const storages: Storage[] = [window.localStorage, window.sessionStorage];
+
+  for (const storage of storages) {
+    const raw = storage.getItem(SESSION_STORAGE_KEY);
+    if (!raw) {
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as Partial<AuthSession> | null;
+      if (
+        !parsed ||
+        typeof parsed.token !== 'string' ||
+        typeof parsed.email !== 'string' ||
+        typeof parsed.role !== 'string' ||
+        typeof parsed.expiresAt !== 'number'
+      ) {
+        storage.removeItem(SESSION_STORAGE_KEY);
+        continue;
+      }
+
+      if (parsed.expiresAt <= Date.now()) {
+        storage.removeItem(SESSION_STORAGE_KEY);
+        continue;
+      }
+
+      return parsed as AuthSession;
+    } catch (error) {
+      console.warn('Failed to parse persisted session:', error);
+      storage.removeItem(SESSION_STORAGE_KEY);
+    }
+  }
+
+  return null;
+};
+
+const persistSession = (session: AuthSession, remember: boolean) => {
+  if (!isBrowserEnvironment()) {
+    return;
+  }
+
+  const payload = JSON.stringify(session);
+  const primary = remember ? window.localStorage : window.sessionStorage;
+  const secondary = remember ? window.sessionStorage : window.localStorage;
+
+  primary.setItem(SESSION_STORAGE_KEY, payload);
+  secondary.removeItem(SESSION_STORAGE_KEY);
+};
+
+const clearStoredSession = () => {
+  if (!isBrowserEnvironment()) {
+    return;
+  }
+  window.localStorage.removeItem(SESSION_STORAGE_KEY);
+  window.sessionStorage.removeItem(SESSION_STORAGE_KEY);
+};
+
+const readLastEmail = (): string | null => {
+  if (!isBrowserEnvironment()) {
+    return null;
+  }
+  const raw = window.localStorage.getItem(LAST_EMAIL_KEY);
+  return raw?.trim() || null;
+};
+
+const storeLastEmail = (email: string) => {
+  if (!isBrowserEnvironment()) {
+    return;
+  }
+  window.localStorage.setItem(LAST_EMAIL_KEY, email);
+};
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
-  const { list } = useAccountsState();
-  const [role, setRole] = useState<AccountRole>('super-admin');
-  const [email, setEmailState] = useState('—');
-  const [rememberMe, setRememberMe] = useState(true);
-  const [emailLocked, setEmailLocked] = useState(false);
+  const [session, setSession] = useState<AuthSession | null>(() => readStoredSession());
+  const [lastEmail, setLastEmail] = useState<string | null>(() => readLastEmail());
 
-  useEffect(() => {
-    if (emailLocked) {
+  const rememberEmail = useCallback((email: string) => {
+    const normalized = email.trim().toLowerCase();
+    if (!normalized) {
       return;
     }
-    const superAdmin = list.find((account) => account.role === 'super-admin');
-    if (superAdmin) {
-      setEmailState(superAdmin.email);
-    }
-  }, [list, emailLocked]);
+    setLastEmail(normalized);
+    storeLastEmail(normalized);
+  }, []);
 
-  const setEmail = (value: string) => {
-    setEmailState(value);
-    setEmailLocked(true);
-  };
-
-  return (
-    <AuthContext.Provider value={{ role, setRole, email, setEmail, rememberMe, setRememberMe }}>
-      {children}
-    </AuthContext.Provider>
+  const requestAccessCode = useCallback<Required<AuthContextValue>['requestAccessCode']>(
+    async (email) => {
+      const normalized = email.trim().toLowerCase();
+      try {
+        const response = await authApi.requestCode(normalized);
+        rememberEmail(response.email);
+        return { ok: true, email: response.email };
+      } catch (error) {
+        if (error instanceof ApiError) {
+          if (error.status === 404) {
+            return { ok: false, error: 'not-found' };
+          }
+          if (error.status === 403) {
+            return { ok: false, error: 'forbidden' };
+          }
+        }
+        console.error('Failed to request access code:', error);
+        return { ok: false, error: 'unknown' };
+      }
+    },
+    [rememberEmail]
   );
+
+  const verifyAccessCode = useCallback<Required<AuthContextValue>['verifyAccessCode']>(
+    async (email, code, remember) => {
+      const normalizedEmail = email.trim().toLowerCase();
+      const trimmedCode = code.trim();
+
+      try {
+        const response = await authApi.verifyCode(normalizedEmail, trimmedCode);
+        const expiresAt = Date.now() + (remember ? LONG_SESSION_MS : SHORT_SESSION_MS);
+        const nextSession: AuthSession = {
+          token: response.token,
+          email: response.email,
+          role: response.role,
+          expiresAt
+        };
+        setSession(nextSession);
+        persistSession(nextSession, remember);
+        rememberEmail(response.email);
+        return { ok: true, session: nextSession };
+      } catch (error) {
+        if (error instanceof ApiError) {
+          if (error.status === 410) {
+            return { ok: false, error: 'expired' };
+          }
+          if (error.status === 401 || error.status === 404) {
+            return { ok: false, error: 'invalid' };
+          }
+        }
+        console.error('Failed to verify access code:', error);
+        return { ok: false, error: 'unknown' };
+      }
+    },
+    [rememberEmail]
+  );
+
+  const logout = useCallback(() => {
+    setSession(null);
+    clearStoredSession();
+  }, []);
+
+  useEffect(() => {
+    if (!session || !isBrowserEnvironment()) {
+      return;
+    }
+
+    const remaining = session.expiresAt - Date.now();
+    if (remaining <= 0) {
+      logout();
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      logout();
+    }, remaining);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [session, logout]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      session,
+      isAuthenticated: Boolean(session),
+      requestAccessCode,
+      verifyAccessCode,
+      logout,
+      lastEmail
+    }),
+    [session, requestAccessCode, verifyAccessCode, logout, lastEmail]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };
 
 export const useAuth = () => {

--- a/frontend/src/modules/auth/LoginScreen.tsx
+++ b/frontend/src/modules/auth/LoginScreen.tsx
@@ -1,0 +1,209 @@
+import { FormEvent, useCallback, useEffect, useState } from 'react';
+import styles from '../../styles/LoginScreen.module.css';
+import { useAuth, RequestCodeError, VerifyCodeError } from './AuthContext';
+
+type LoginStep = 'request' | 'verify';
+
+type BannerState = { type: 'info' | 'error'; text: string } | null;
+
+const normalizeEmail = (value: string) => value.trim().toLowerCase();
+
+const mapRequestError = (error: RequestCodeError) => {
+  switch (error) {
+    case 'not-found':
+      return 'We could not find an admin account with this email.';
+    case 'forbidden':
+      return 'Only admin accounts can access this platform.';
+    default:
+      return 'Unable to send the access code. Try again in a moment.';
+  }
+};
+
+const mapVerifyError = (error: VerifyCodeError) => {
+  switch (error) {
+    case 'expired':
+      return 'The code has expired. Request a new one to continue.';
+    case 'invalid':
+      return 'The code is invalid. Check the digits and try again.';
+    default:
+      return 'Unable to verify the code right now. Try again later.';
+  }
+};
+
+export const LoginScreen = () => {
+  const { requestAccessCode, verifyAccessCode, lastEmail } = useAuth();
+  const [step, setStep] = useState<LoginStep>('request');
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [rememberMe, setRememberMe] = useState(true);
+  const [banner, setBanner] = useState<BannerState>(null);
+  const [isRequesting, setIsRequesting] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const params = new URLSearchParams(window.location.search);
+    const candidate = params.get('email') ?? params.get('invited');
+    const initial = normalizeEmail(candidate ?? '') || lastEmail || '';
+    if (initial) {
+      setEmail(initial);
+    }
+  }, [lastEmail]);
+
+  const handleRequest = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const normalized = normalizeEmail(email);
+      if (!normalized) {
+        setBanner({ type: 'error', text: 'Enter the email that received your invitation.' });
+        return;
+      }
+      setIsRequesting(true);
+      const result = await requestAccessCode(normalized);
+      setIsRequesting(false);
+      if (!result.ok) {
+        setBanner({ type: 'error', text: mapRequestError(result.error) });
+        return;
+      }
+      setEmail(result.email);
+      setBanner({
+        type: 'info',
+        text: `We sent a one-time code to ${result.email}. Check your inbox.`
+      });
+      setCode('');
+      setStep('verify');
+    },
+    [email, requestAccessCode]
+  );
+
+  const handleVerify = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const normalizedEmail = normalizeEmail(email);
+      const trimmedCode = code.trim();
+      if (!normalizedEmail) {
+        setBanner({ type: 'error', text: 'Enter the email that received your invitation.' });
+        return;
+      }
+      if (!trimmedCode) {
+        setBanner({ type: 'error', text: 'Enter the six-digit code from your email.' });
+        return;
+      }
+      setIsVerifying(true);
+      const result = await verifyAccessCode(normalizedEmail, trimmedCode, rememberMe);
+      setIsVerifying(false);
+      if (!result.ok) {
+        setBanner({ type: 'error', text: mapVerifyError(result.error) });
+        if (result.error !== 'expired') {
+          setCode('');
+        }
+      }
+    },
+    [email, code, rememberMe, verifyAccessCode]
+  );
+
+  const handleResend = useCallback(async () => {
+    const normalized = normalizeEmail(email);
+    if (!normalized) {
+      setBanner({ type: 'error', text: 'Enter the email that received your invitation.' });
+      return;
+    }
+    setIsRequesting(true);
+    const result = await requestAccessCode(normalized);
+    setIsRequesting(false);
+    if (!result.ok) {
+      setBanner({ type: 'error', text: mapRequestError(result.error) });
+      return;
+    }
+    setBanner({ type: 'info', text: `A new code was sent to ${result.email}.` });
+  }, [email, requestAccessCode]);
+
+  const handleChangeEmail = useCallback(() => {
+    setStep('request');
+    setCode('');
+    setBanner(null);
+    setIsVerifying(false);
+  }, []);
+
+  return (
+    <section className={styles.wrapper}>
+      <div className={styles.card}>
+        <div className={styles.brandMark}>R2</div>
+        <h1 className={styles.title}>Sign in with a one-time code</h1>
+        <p className={styles.subtitle}>Use the email that received your invitation to access the platform.</p>
+
+        {banner && (
+          <div className={banner.type === 'info' ? styles.infoBanner : styles.errorBanner}>{banner.text}</div>
+        )}
+
+        <form
+          className={styles.form}
+          onSubmit={step === 'request' ? handleRequest : handleVerify}
+          noValidate
+        >
+          <label className={styles.label}>
+            Email
+            <input
+              className={styles.input}
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="email@company.com"
+              disabled={step === 'verify'}
+            />
+          </label>
+
+          {step === 'verify' && (
+            <>
+              <label className={styles.label}>
+                Access code
+                <input
+                  className={styles.input}
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  autoComplete="one-time-code"
+                  value={code}
+                  onChange={(event) => setCode(event.target.value)}
+                  placeholder="123456"
+                  maxLength={6}
+                  disabled={isVerifying}
+                />
+              </label>
+              <label className={styles.checkboxLabel}>
+                <input
+                  type="checkbox"
+                  checked={rememberMe}
+                  onChange={(event) => setRememberMe(event.target.checked)}
+                  disabled={isVerifying}
+                />
+                Keep me signed in on this device
+              </label>
+            </>
+          )}
+
+          <button
+            className={styles.primaryButton}
+            type="submit"
+            disabled={step === 'request' ? isRequesting : isVerifying || isRequesting}
+          >
+            {step === 'request' ? (isRequesting ? 'Sending...' : 'Send access code') : isVerifying ? 'Signing in...' : 'Sign in'}
+          </button>
+        </form>
+
+        {step === 'verify' && (
+          <div className={styles.actionsRow}>
+            <button className={styles.linkButton} type="button" onClick={handleResend} disabled={isRequesting}>
+              Resend code
+            </button>
+            <button className={styles.linkButton} type="button" onClick={handleChangeEmail}>
+              Use a different email
+            </button>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};

--- a/frontend/src/modules/auth/services/authApi.ts
+++ b/frontend/src/modules/auth/services/authApi.ts
@@ -1,0 +1,21 @@
+import { apiRequest } from '../../../shared/api/httpClient';
+import { AccountRole } from '../../../shared/types/account';
+
+interface VerifyCodeResponse {
+  token: string;
+  email: string;
+  role: AccountRole;
+}
+
+export const authApi = {
+  requestCode: async (email: string) =>
+    apiRequest<{ email: string }>('/auth/request-code', {
+      method: 'POST',
+      body: { email }
+    }),
+  verifyCode: async (email: string, code: string) =>
+    apiRequest<VerifyCodeResponse>('/auth/verify-code', {
+      method: 'POST',
+      body: { email, code }
+    })
+};

--- a/frontend/src/styles/AppLayout.module.css
+++ b/frontend/src/styles/AppLayout.module.css
@@ -15,7 +15,7 @@
 
 .topbar {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
   gap: 24px;
   background: rgba(255, 255, 255, 0.85);
@@ -38,21 +38,18 @@
   color: #475569;
 }
 
-.roleSelector {
-  display: flex;
-  flex-direction: column;
+.roleBadge {
+  display: inline-flex;
+  align-items: center;
   gap: 8px;
+  border-radius: 999px;
+  padding: 10px 18px;
   font-size: 14px;
-  color: #334155;
-}
-
-.roleSelector select {
-  border: 1px solid rgba(148, 163, 184, 0.6);
-  border-radius: 12px;
-  padding: 8px 12px;
-  font-size: 14px;
-  background: #ffffff;
-  color: #0f172a;
+  font-weight: 600;
+  color: #1d4ed8;
+  background: rgba(59, 130, 246, 0.16);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  text-transform: capitalize;
 }
 
 .pageContainer {

--- a/frontend/src/styles/LoginScreen.module.css
+++ b/frontend/src/styles/LoginScreen.module.css
@@ -1,0 +1,162 @@
+.wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100%;
+  padding: 48px 24px;
+  background: radial-gradient(circle at top, #e2e8f0 0%, #f8fafc 45%, #f1f5f9 100%);
+}
+
+.card {
+  width: 100%;
+  max-width: 420px;
+  background: rgba(255, 255, 255, 0.96);
+  border-radius: 28px;
+  padding: 40px;
+  box-shadow: 0 40px 60px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.brandMark {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, #38bdf8 0%, #818cf8 100%);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 20px;
+  color: #f8fafc;
+}
+
+.title {
+  margin: 0;
+  font-size: 26px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.subtitle {
+  margin: -12px 0 0;
+  font-size: 15px;
+  color: #475569;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 14px;
+  color: #1e293b;
+}
+
+.input {
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  padding: 12px 14px;
+  font-size: 15px;
+  background: rgba(255, 255, 255, 0.9);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+}
+
+.input:disabled {
+  background: #e2e8f0;
+  cursor: not-allowed;
+}
+
+.checkboxLabel {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  color: #334155;
+}
+
+.checkboxLabel input {
+  width: 18px;
+  height: 18px;
+}
+
+.primaryButton {
+  border: none;
+  border-radius: 14px;
+  padding: 14px;
+  font-size: 15px;
+  font-weight: 600;
+  color: #f8fafc;
+  background: linear-gradient(135deg, #3b82f6, #6366f1);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primaryButton:disabled {
+  opacity: 0.7;
+  cursor: wait;
+  box-shadow: none;
+  transform: none;
+}
+
+.primaryButton:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(79, 70, 229, 0.25);
+}
+
+.infoBanner,
+.errorBanner {
+  border-radius: 14px;
+  padding: 14px 16px;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.infoBanner {
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+}
+
+.errorBanner {
+  background: rgba(248, 113, 113, 0.12);
+  color: #b91c1c;
+}
+
+.actionsRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  font-size: 14px;
+}
+
+.linkButton {
+  border: none;
+  background: transparent;
+  color: #2563eb;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.linkButton:disabled {
+  color: rgba(37, 99, 235, 0.6);
+  cursor: wait;
+}
+
+@media (max-width: 480px) {
+  .card {
+    padding: 28px 24px;
+    border-radius: 22px;
+  }
+}

--- a/frontend/src/styles/Sidebar.module.css
+++ b/frontend/src/styles/Sidebar.module.css
@@ -70,6 +70,16 @@
 
 .logoutBlock {
   margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sessionInfo {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(226, 232, 240, 0.75);
+  word-break: break-all;
 }
 
 .logoutButton {


### PR DESCRIPTION
## Summary
- restrict access code generation to admin accounts, improve error responses, and enrich invitation emails with activation links and guidance
- add an auth API client together with a persistent AuthContext and a dedicated login screen for requesting and verifying one-time codes
- gate the application UI behind authentication, surface the signed-in state in the layout/sidebar, synchronise shared state with the active session, and clarify invitation success messaging

## Testing
- npm run build (backend) *(fails: missing installed dependencies in this environment)*
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68e248ed37ec8330a34cdca3c3958b03